### PR TITLE
Add support for iron

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           . /opt/ros/${{ matrix.ros_distribution }}/setup.sh
           apt update
           apt install -y curl
-          rosdep update
+          rosdep update --include-eol-distros
           rosdep install -i -y --from-paths src/Rcl.NET.Tests
 
       - name: Setup .NET 7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,14 @@ jobs:
         ros_distribution:
           - foxy
           - humble
+          - iron
         include:
           - ros_distribution: foxy
             docker_image: ros:foxy-ros-base
           - ros_distribution: humble
             docker_image: ros:humble-ros-base
+          - ros_distribution: iron
+            docker_image: ros:iron-ros-base
     container:
       image: ${{ matrix.docker_image }}
     steps:
@@ -67,11 +70,14 @@ jobs:
         ros_distribution:
           - foxy
           - humble
+          - iron
         include:
+          - ros_distribution: iron
+            ros_archive: https://github.com/ros2/ros2/releases/download/release-iron-20230717/ros2-iron-20230717-windows-release-amd64.zip
           - ros_distribution: humble
-            ros_archive: https://github.com/ros2/ros2/releases/download/release-humble-20230308/ros2-humble-20230308-windows-release-amd64.zip
+            ros_archive: https://github.com/ros2/ros2/releases/download/release-humble-20230724/ros2-humble-20230724-windows-release-amd64.zip
           - ros_distribution: foxy
-            ros_archive: https://github.com/ros2/ros2/releases/download/release-foxy-20230322/ros2-foxy-20230322-windows-release-amd64.zip
+            ros_archive: https://github.com/ros2/ros2/releases/download/release-foxy-20230620/ros2-foxy-20230620-windows-release-amd64.zip
     steps:
       - uses: actions/checkout@v3
   

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ rclnet is a fast and easy-to-use .NET wrapper over ROS 2 client library, allowin
 | Events                  | ✅      | Event handlers can be registered via `SubscriptionOptions` or `PublisherOptions` when creating the subscirption or publisher.                                                                                                                |
 | ROS Graph               | ✅      | Managed implementation.                                                                                                                                                                                                                      |
 | Logging                 | ✅      | Supports logging to stdout, /rosout and log files. Configurable with `--ros-args`.                                                                                                                                                           |
-| Content Filtered Topics | ✅      | Available since humble. 
-| Network Flow Endpoints  | ✅      | Available since galactic.<br/>Network flow endpoints of publishers and subscriptions can be retrieved via `IRclPublisher.Endpoints` and `IRclSubscription.Endpoints` property.<br/>Unique network flow endpoints requirement can be configured when creating `SubscriptionOptions` and `PublisherOptions`.|
-| Parameter Service       | ⚠️      | Supports loading parameters from command-line arguments and parameter files.<br/>Locally declared parameters are exposed via [Parameter API](https://design.ros2.org/articles/ros_parameters.html).<br/>Parameter client is not implemented. |
-| Lifecycle Nodes         | ❌      | N/A                                                                                                                                                                                                                                          |
+| [Content Filtered Topics](https://github.com/ros2/design/blob/918c09758ed4c0854aa128b9c8ed0051c21a6590/articles/content_filtering.md) | ✅      | Available since humble. 
+| [Network Flow Endpoints](https://design.ros2.org/articles/unique_network_flows.html)  | ✅      | Available since galactic.<br/>Network flow endpoints of publishers and subscriptions can be retrieved via `IRclPublisher.Endpoints` and `IRclSubscription.Endpoints` property.<br/>Unique network flow endpoints requirement can be configured when creating `SubscriptionOptions` and `PublisherOptions`.|
+| [Service Introspection](https://github.com/ros-infrastructure/rep/blob/jacob/service_introspection/rep-2012.rst)   | ✅      | Available since iron. |
+| [Parameter Service](https://design.ros2.org/articles/ros_parameters.html)       | ⚠️      | Supports loading parameters from command-line arguments and parameter files.<br/>Locally declared parameters are exposed via Parameter API.<br/>Parameter client is not implemented. |
+| [Lifecycle Nodes](https://design.ros2.org/articles/node_lifecycle.html)         | ❌      | N/A                                                                                                                                                                                                                                          |
 
 ✅Supported ⚠️Partial support ❌Not supported ⏳In development
 
@@ -35,6 +36,7 @@ Supported .NET Versions:
 - .NET 7
 
 Supported ROS 2 Distributions:
+- Iron Irwini
 - Humble Hawksbill
 - Foxy Fitzroy
 

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Accel.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Accel.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Accel : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Accel";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -42,13 +42,13 @@ namespace Rosidl.Messages.Geometry
         /// </summary>
         /// <param name='linear'>
         /// This expresses acceleration in free space broken into its linear and angular parts.
-        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear]]></c>)</para>
         /// </param>
         /// <param name='angular'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Accel(
             global::Rosidl.Messages.Geometry.Vector3? @linear = null,
             global::Rosidl.Messages.Geometry.Vector3? @angular = null
@@ -65,7 +65,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Accel(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Linear = new global::Rosidl.Messages.Geometry.Vector3(in priv.Linear, textEncoding);
@@ -77,28 +77,28 @@ namespace Rosidl.Messages.Geometry
         /// This expresses acceleration in free space broken into its linear and angular parts.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Linear { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Angular { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Linear.WriteTo(ref priv.Linear, textEncoding);
@@ -106,49 +106,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Accel(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -167,31 +167,31 @@ namespace Rosidl.Messages.Geometry
             /// This expresses acceleration in free space broken into its linear and angular parts.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Linear;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Angular;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -199,7 +199,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -207,28 +207,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -238,7 +238,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -248,18 +248,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -269,21 +269,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -294,7 +294,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -305,7 +305,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -319,7 +319,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -333,7 +333,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -347,7 +347,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -358,7 +358,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -389,28 +389,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -418,7 +418,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -426,7 +426,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -434,21 +434,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -457,21 +457,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -481,7 +481,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -491,39 +491,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -534,7 +534,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -545,7 +545,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -559,7 +559,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -573,7 +573,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -587,7 +587,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -598,7 +598,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/AccelStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/AccelStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class AccelStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/AccelStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -42,13 +42,13 @@ namespace Rosidl.Messages.Geometry
         /// </summary>
         /// <param name='header'>
         /// An accel with reference coordinate frame and timestamp
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='accel'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Accel accel]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Accel accel]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public AccelStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Accel? @accel = null
@@ -65,7 +65,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public AccelStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -77,28 +77,28 @@ namespace Rosidl.Messages.Geometry
         /// An accel with reference coordinate frame and timestamp
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Accel accel]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Accel accel]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Accel Accel { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -106,49 +106,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new AccelStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -167,31 +167,31 @@ namespace Rosidl.Messages.Geometry
             /// An accel with reference coordinate frame and timestamp
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Accel accel]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Accel accel]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Accel.Priv Accel;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -199,7 +199,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -207,28 +207,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -238,7 +238,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -248,18 +248,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -269,21 +269,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -294,7 +294,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -305,7 +305,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -319,7 +319,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -333,7 +333,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -347,7 +347,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -358,7 +358,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -389,28 +389,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -418,7 +418,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -426,7 +426,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -434,21 +434,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -457,21 +457,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -481,7 +481,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -491,39 +491,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -534,7 +534,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -545,7 +545,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -559,7 +559,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -573,7 +573,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -587,7 +587,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -598,7 +598,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/AccelWithCovariance.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/AccelWithCovariance.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class AccelWithCovariance : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/AccelWithCovariance";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,7 +41,7 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="AccelWithCovariance"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='accel'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Accel accel]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Accel accel]]></c>
         /// </param>
         /// <param name='covariance'>
         /// Row-major representation of the 6x6 covariance matrix
@@ -51,7 +51,7 @@ namespace Rosidl.Messages.Geometry
         /// <para>(originally defined as: <c><![CDATA[float64[36] covariance]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public AccelWithCovariance(
             global::Rosidl.Messages.Geometry.Accel? @accel = null,
             double[]? @covariance = null
@@ -76,7 +76,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public AccelWithCovariance(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Accel = new global::Rosidl.Messages.Geometry.Accel(in priv.Accel, textEncoding);
@@ -85,10 +85,10 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Accel accel]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Accel accel]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Accel Accel { get; set; }
         
         private double[] __backingField__Covariance;
@@ -103,7 +103,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64[36] covariance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] Covariance
         {
             get
@@ -118,14 +118,14 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Accel.WriteTo(ref priv.Accel, textEncoding);
@@ -133,49 +133,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new AccelWithCovariance(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -191,7 +191,7 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Accel accel]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Accel accel]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Accel.Priv Accel;
             
@@ -207,7 +207,7 @@ namespace Rosidl.Messages.Geometry
             /// Originally defined as: <c><![CDATA[float64[36] covariance]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> Covariance
             {
                 get
@@ -217,21 +217,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -239,7 +239,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -247,28 +247,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -278,7 +278,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -288,18 +288,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -313,21 +313,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -338,7 +338,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -349,7 +349,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -363,7 +363,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -377,7 +377,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -391,7 +391,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -402,7 +402,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -433,28 +433,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -462,7 +462,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -470,7 +470,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -478,21 +478,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -501,21 +501,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -525,7 +525,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -535,39 +535,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -617,7 +617,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -631,7 +631,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -642,7 +642,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/AccelWithCovarianceStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/AccelWithCovarianceStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class AccelWithCovarianceStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/AccelWithCovarianceStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -42,13 +42,13 @@ namespace Rosidl.Messages.Geometry
         /// </summary>
         /// <param name='header'>
         /// This represents an estimated accel with reference coordinate frame and timestamp.
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='accel'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/AccelWithCovariance accel]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/AccelWithCovariance accel]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public AccelWithCovarianceStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.AccelWithCovariance? @accel = null
@@ -65,7 +65,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public AccelWithCovarianceStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -77,28 +77,28 @@ namespace Rosidl.Messages.Geometry
         /// This represents an estimated accel with reference coordinate frame and timestamp.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/AccelWithCovariance accel]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/AccelWithCovariance accel]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.AccelWithCovariance Accel { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -106,49 +106,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new AccelWithCovarianceStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -167,31 +167,31 @@ namespace Rosidl.Messages.Geometry
             /// This represents an estimated accel with reference coordinate frame and timestamp.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/AccelWithCovariance accel]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/AccelWithCovariance accel]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.AccelWithCovariance.Priv Accel;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -199,7 +199,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -207,28 +207,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -238,7 +238,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -248,18 +248,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -269,21 +269,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -294,7 +294,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -305,7 +305,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -319,7 +319,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -333,7 +333,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -347,7 +347,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -358,7 +358,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -389,28 +389,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -418,7 +418,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -426,7 +426,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -434,21 +434,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -457,21 +457,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -481,7 +481,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -491,39 +491,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -534,7 +534,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -545,7 +545,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -559,7 +559,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -573,7 +573,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -587,7 +587,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -598,7 +598,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Inertia.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Inertia.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Inertia : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Inertia";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -46,7 +46,7 @@ namespace Rosidl.Messages.Geometry
         /// </param>
         /// <param name='com'>
         /// Center of mass [m]
-        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/Vector3 com]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 com]]></c>)</para>
         /// </param>
         /// <param name='ixx'>
         /// Inertia Tensor [kg-m^2]
@@ -71,7 +71,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 izz]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Inertia(
             double @m = 0d,
             global::Rosidl.Messages.Geometry.Vector3? @com = null,
@@ -100,7 +100,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Inertia(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.M = priv.M;
@@ -121,17 +121,17 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 m]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double M { get; set; }
         
         /// <summary>
         /// Center of mass [m]
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 com]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 com]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Com { get; set; }
         
         /// <summary>
@@ -144,53 +144,53 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 ixx]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Ixx { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 ixy]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Ixy { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 ixz]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Ixz { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 iyy]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Iyy { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 iyz]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Iyz { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 izz]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Izz { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.M = this.M;
@@ -204,49 +204,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Inertia(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Geometry
             /// Center of mass [m]
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 com]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 com]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Com;
             
@@ -314,21 +314,21 @@ namespace Rosidl.Messages.Geometry
             public double Izz;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -336,7 +336,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -344,28 +344,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -375,7 +375,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -385,18 +385,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -412,21 +412,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -437,7 +437,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -448,7 +448,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -462,7 +462,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -476,7 +476,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -490,7 +490,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -501,7 +501,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -532,28 +532,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -577,21 +577,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -600,21 +600,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -624,7 +624,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -634,39 +634,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -677,7 +677,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -688,7 +688,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -702,7 +702,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -716,7 +716,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -730,7 +730,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -741,7 +741,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/InertiaStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/InertiaStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class InertiaStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/InertiaStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="InertiaStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='inertia'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Inertia inertia]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Inertia inertia]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public InertiaStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Inertia? @inertia = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public InertiaStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Inertia inertia]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Inertia inertia]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Inertia Inertia { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new InertiaStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Inertia inertia]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Inertia inertia]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Inertia.Priv Inertia;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Point.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Point.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Point : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Point";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -51,7 +51,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 z]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Point(
             double @x = 0d,
             double @y = 0d,
@@ -70,7 +70,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Point(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.X = priv.X;
@@ -86,32 +86,32 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 x]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double X { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 y]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Y { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 z]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Z { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.X = this.X;
@@ -120,49 +120,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Point(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -196,21 +196,21 @@ namespace Rosidl.Messages.Geometry
             public double Z;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -226,28 +226,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -257,7 +257,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -267,18 +267,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -289,21 +289,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -314,7 +314,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -325,7 +325,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -339,7 +339,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -353,7 +353,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -367,7 +367,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -378,7 +378,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -409,28 +409,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -438,7 +438,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -446,7 +446,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -454,21 +454,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -477,21 +477,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -501,7 +501,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -511,39 +511,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -554,7 +554,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -565,7 +565,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -579,7 +579,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -593,7 +593,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -607,7 +607,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -618,7 +618,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Point32.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Point32.cs
@@ -29,11 +29,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Point32 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Point32";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -56,7 +56,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float32 z]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Point32(
             float @x = 0f,
             float @y = 0f,
@@ -75,7 +75,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Point32(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.X = priv.X;
@@ -88,32 +88,32 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float32 x]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float X { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float32 y]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Y { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float32 z]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Z { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.X = this.X;
@@ -122,49 +122,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Point32(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -201,21 +201,21 @@ namespace Rosidl.Messages.Geometry
             public float Z;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -223,7 +223,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -231,28 +231,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -262,7 +262,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -272,18 +272,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -294,21 +294,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -319,7 +319,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -330,7 +330,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -344,7 +344,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -358,7 +358,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -372,7 +372,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -383,7 +383,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -420,28 +420,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -449,7 +449,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -457,7 +457,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -465,21 +465,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -488,21 +488,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -512,7 +512,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -522,39 +522,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -565,7 +565,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -576,7 +576,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -590,7 +590,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -604,7 +604,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -618,7 +618,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -629,7 +629,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PointStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PointStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class PointStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/PointStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="PointStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='point'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Point point]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point point]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PointStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Point? @point = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PointStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Point point]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point point]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Point Point { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PointStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Point point]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point point]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Point.Priv Point;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Polygon.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Polygon.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Polygon : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Polygon";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,10 +41,10 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="Polygon"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='points'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Point32[] points]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point32[] points]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Polygon(
             global::Rosidl.Messages.Geometry.Point32[]? @points = null
         )
@@ -59,7 +59,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Polygon(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Points = new global::Rosidl.Messages.Geometry.Point32[priv.Points.Size];
@@ -72,21 +72,21 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Point32[] points]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point32[] points]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Point32[] Points { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Points = new global::Rosidl.Messages.Geometry.Point32.PrivSequence(this.Points.Length);
@@ -98,49 +98,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Polygon(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -156,26 +156,26 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Point32[] points]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point32[] points]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Point32.PrivSequence Points;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -183,7 +183,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -191,28 +191,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -222,7 +222,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -232,18 +232,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -252,21 +252,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -277,7 +277,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -288,7 +288,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -302,7 +302,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -316,7 +316,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -330,7 +330,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -341,7 +341,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -372,28 +372,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -401,7 +401,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -409,7 +409,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -417,21 +417,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -440,21 +440,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -464,7 +464,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -474,39 +474,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -517,7 +517,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -528,7 +528,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -542,7 +542,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -556,7 +556,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -570,7 +570,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -581,7 +581,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PolygonStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PolygonStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class PolygonStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/PolygonStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="PolygonStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='polygon'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Polygon polygon]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Polygon polygon]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PolygonStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Polygon? @polygon = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PolygonStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Polygon polygon]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Polygon polygon]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Polygon Polygon { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PolygonStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Polygon polygon]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Polygon polygon]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Polygon.Priv Polygon;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Pose.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Pose.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Pose : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Pose";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="Pose"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='position'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Point position]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point position]]></c>
         /// </param>
         /// <param name='orientation'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion orientation]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion orientation]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Pose(
             global::Rosidl.Messages.Geometry.Point? @position = null,
             global::Rosidl.Messages.Geometry.Quaternion? @orientation = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Pose(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Position = new global::Rosidl.Messages.Geometry.Point(in priv.Position, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Point position]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point position]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Point Position { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion orientation]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion orientation]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Quaternion Orientation { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Position.WriteTo(ref priv.Position, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Pose(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Point position]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point position]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Point.Priv Position;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion orientation]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion orientation]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Quaternion.Priv Orientation;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Pose2D.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Pose2D.cs
@@ -24,11 +24,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Pose2D : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Pose2D";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -51,7 +51,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 theta]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Pose2D(
             double @x = 0d,
             double @y = 0d,
@@ -70,7 +70,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Pose2D(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.X = priv.X;
@@ -83,32 +83,32 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 x]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double X { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 y]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Y { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 theta]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Theta { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.X = this.X;
@@ -117,49 +117,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Pose2D(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -191,21 +191,21 @@ namespace Rosidl.Messages.Geometry
             public double Theta;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -213,7 +213,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -221,28 +221,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -252,7 +252,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -262,18 +262,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -284,21 +284,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -309,7 +309,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -320,7 +320,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -334,7 +334,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -348,7 +348,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -362,7 +362,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -373,7 +373,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PoseArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PoseArray.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class PoseArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/PoseArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="PoseArray"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='poses'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Pose[] poses]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose[] poses]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PoseArray(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Pose[]? @poses = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PoseArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -79,28 +79,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Pose[] poses]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose[] poses]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Pose[] Poses { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -114,49 +114,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PoseArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -172,31 +172,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Pose[] poses]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose[] poses]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Pose.PrivSequence Poses;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -204,7 +204,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -212,28 +212,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -243,7 +243,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -253,18 +253,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -274,21 +274,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -299,7 +299,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -310,7 +310,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -324,7 +324,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -338,7 +338,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -352,7 +352,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -363,7 +363,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -394,28 +394,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -423,7 +423,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -431,7 +431,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -462,21 +462,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -486,7 +486,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -496,39 +496,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -539,7 +539,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -564,7 +564,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -592,7 +592,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PoseStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PoseStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class PoseStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/PoseStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="PoseStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='pose'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Pose pose]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose pose]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PoseStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Pose? @pose = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PoseStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Pose pose]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose pose]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Pose Pose { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PoseStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Pose pose]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose pose]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Pose.Priv Pose;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PoseWithCovariance.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PoseWithCovariance.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class PoseWithCovariance : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/PoseWithCovariance";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,7 +41,7 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="PoseWithCovariance"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='pose'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Pose pose]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose pose]]></c>
         /// </param>
         /// <param name='covariance'>
         /// Row-major representation of the 6x6 covariance matrix
@@ -51,7 +51,7 @@ namespace Rosidl.Messages.Geometry
         /// <para>(originally defined as: <c><![CDATA[float64[36] covariance]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PoseWithCovariance(
             global::Rosidl.Messages.Geometry.Pose? @pose = null,
             double[]? @covariance = null
@@ -76,7 +76,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PoseWithCovariance(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Pose = new global::Rosidl.Messages.Geometry.Pose(in priv.Pose, textEncoding);
@@ -85,10 +85,10 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Pose pose]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose pose]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Pose Pose { get; set; }
         
         private double[] __backingField__Covariance;
@@ -103,7 +103,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64[36] covariance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] Covariance
         {
             get
@@ -118,14 +118,14 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Pose.WriteTo(ref priv.Pose, textEncoding);
@@ -133,49 +133,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PoseWithCovariance(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -191,7 +191,7 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Pose pose]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Pose pose]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Pose.Priv Pose;
             
@@ -207,7 +207,7 @@ namespace Rosidl.Messages.Geometry
             /// Originally defined as: <c><![CDATA[float64[36] covariance]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> Covariance
             {
                 get
@@ -217,21 +217,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -239,7 +239,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -247,28 +247,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -278,7 +278,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -288,18 +288,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -313,21 +313,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -338,7 +338,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -349,7 +349,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -363,7 +363,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -377,7 +377,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -391,7 +391,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -402,7 +402,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -433,28 +433,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -462,7 +462,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -470,7 +470,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -478,21 +478,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -501,21 +501,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -525,7 +525,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -535,39 +535,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -617,7 +617,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -631,7 +631,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -642,7 +642,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PoseWithCovarianceStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/PoseWithCovarianceStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class PoseWithCovarianceStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/PoseWithCovarianceStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="PoseWithCovarianceStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='pose'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/PoseWithCovariance pose]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/PoseWithCovariance pose]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PoseWithCovarianceStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.PoseWithCovariance? @pose = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PoseWithCovarianceStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/PoseWithCovariance pose]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/PoseWithCovariance pose]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.PoseWithCovariance Pose { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PoseWithCovarianceStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/PoseWithCovariance pose]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/PoseWithCovariance pose]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.PoseWithCovariance.Priv Pose;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Quaternion.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Quaternion.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Quaternion : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Quaternion";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -53,7 +53,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 w 1]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Quaternion(
             double @x = 0d,
             double @y = 0d,
@@ -74,7 +74,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Quaternion(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.X = priv.X;
@@ -88,39 +88,39 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 x 0]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double X { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 y 0]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Y { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 z 0]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Z { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 w 1]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double W { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.X = this.X;
@@ -130,49 +130,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Quaternion(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -208,21 +208,21 @@ namespace Rosidl.Messages.Geometry
             public double W;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -230,7 +230,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -238,28 +238,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -269,7 +269,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -279,18 +279,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -302,21 +302,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -327,7 +327,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -338,7 +338,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -352,7 +352,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -366,7 +366,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -380,7 +380,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -391,7 +391,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -422,28 +422,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -451,7 +451,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -459,7 +459,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -467,21 +467,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -490,21 +490,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -514,7 +514,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -524,39 +524,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -567,7 +567,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -592,7 +592,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -606,7 +606,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -620,7 +620,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -631,7 +631,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/QuaternionStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/QuaternionStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class QuaternionStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/QuaternionStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="QuaternionStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='quaternion'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion quaternion]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion quaternion]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public QuaternionStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Quaternion? @quaternion = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public QuaternionStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion quaternion]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion quaternion]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Quaternion Quaternion { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new QuaternionStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion quaternion]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion quaternion]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Quaternion.Priv Quaternion;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Transform.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Transform.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Transform : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Transform";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="Transform"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='translation'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 translation]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 translation]]></c>
         /// </param>
         /// <param name='rotation'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion rotation]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion rotation]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Transform(
             global::Rosidl.Messages.Geometry.Vector3? @translation = null,
             global::Rosidl.Messages.Geometry.Quaternion? @rotation = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Transform(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Translation = new global::Rosidl.Messages.Geometry.Vector3(in priv.Translation, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 translation]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 translation]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Translation { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion rotation]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion rotation]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Quaternion Rotation { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Translation.WriteTo(ref priv.Translation, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Transform(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 translation]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 translation]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Translation;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion rotation]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion rotation]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Quaternion.Priv Rotation;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/TransformStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/TransformStamped.cs
@@ -32,11 +32,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class TransformStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/TransformStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -51,7 +51,7 @@ namespace Rosidl.Messages.Geometry
         /// </summary>
         /// <param name='header'>
         /// The frame id in the header is used as the reference frame of this transform.
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='childFrameId'>
         /// The frame id of the child frame to which this transform points.
@@ -59,10 +59,10 @@ namespace Rosidl.Messages.Geometry
         /// </param>
         /// <param name='transform'>
         /// Translation and rotation in 3-dimensions of child_frame_id from header.frame_id.
-        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/Transform transform]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/msg/Transform transform]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TransformStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             string @childFrameId = "",
@@ -81,7 +81,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TransformStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -94,10 +94,10 @@ namespace Rosidl.Messages.Geometry
         /// The frame id in the header is used as the reference frame of this transform.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -107,28 +107,28 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[string child_frame_id]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string ChildFrameId { get; set; }
         
         /// <summary>
         /// Translation and rotation in 3-dimensions of child_frame_id from header.frame_id.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Transform transform]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Transform transform]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Transform Transform { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -137,49 +137,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new TransformStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -207,7 +207,7 @@ namespace Rosidl.Messages.Geometry
             /// The frame id in the header is used as the reference frame of this transform.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -223,26 +223,26 @@ namespace Rosidl.Messages.Geometry
             /// Translation and rotation in 3-dimensions of child_frame_id from header.frame_id.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Transform transform]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Transform transform]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Geometry.Transform.Priv Transform;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -250,7 +250,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -258,28 +258,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -289,7 +289,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -299,18 +299,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -321,21 +321,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -357,7 +357,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -385,7 +385,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -399,7 +399,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -410,7 +410,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -450,28 +450,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -479,7 +479,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -487,7 +487,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -495,21 +495,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -518,21 +518,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -542,7 +542,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -552,39 +552,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -595,7 +595,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -606,7 +606,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -620,7 +620,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -634,7 +634,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -648,7 +648,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -659,7 +659,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Twist.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Twist.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Twist : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Twist";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="Twist"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='linear'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear]]></c>
         /// </param>
         /// <param name='angular'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Twist(
             global::Rosidl.Messages.Geometry.Vector3? @linear = null,
             global::Rosidl.Messages.Geometry.Vector3? @angular = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Twist(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Linear = new global::Rosidl.Messages.Geometry.Vector3(in priv.Linear, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Linear { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Angular { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Linear.WriteTo(ref priv.Linear, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Twist(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Linear;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Angular;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/TwistStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/TwistStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class TwistStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/TwistStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="TwistStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='twist'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Twist twist]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist twist]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TwistStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Twist? @twist = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TwistStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Twist twist]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist twist]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Twist Twist { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new TwistStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Twist twist]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist twist]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Twist.Priv Twist;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/TwistWithCovariance.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/TwistWithCovariance.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class TwistWithCovariance : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/TwistWithCovariance";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,7 +41,7 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="TwistWithCovariance"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='twist'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Twist twist]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist twist]]></c>
         /// </param>
         /// <param name='covariance'>
         /// Row-major representation of the 6x6 covariance matrix
@@ -51,7 +51,7 @@ namespace Rosidl.Messages.Geometry
         /// <para>(originally defined as: <c><![CDATA[float64[36] covariance]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TwistWithCovariance(
             global::Rosidl.Messages.Geometry.Twist? @twist = null,
             double[]? @covariance = null
@@ -76,7 +76,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TwistWithCovariance(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Twist = new global::Rosidl.Messages.Geometry.Twist(in priv.Twist, textEncoding);
@@ -85,10 +85,10 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Twist twist]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist twist]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Twist Twist { get; set; }
         
         private double[] __backingField__Covariance;
@@ -103,7 +103,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64[36] covariance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] Covariance
         {
             get
@@ -118,14 +118,14 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Twist.WriteTo(ref priv.Twist, textEncoding);
@@ -133,49 +133,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new TwistWithCovariance(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -191,7 +191,7 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Twist twist]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist twist]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Twist.Priv Twist;
             
@@ -207,7 +207,7 @@ namespace Rosidl.Messages.Geometry
             /// Originally defined as: <c><![CDATA[float64[36] covariance]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> Covariance
             {
                 get
@@ -217,21 +217,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -239,7 +239,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -247,28 +247,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -278,7 +278,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -288,18 +288,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -313,21 +313,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -338,7 +338,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -349,7 +349,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -363,7 +363,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -377,7 +377,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -391,7 +391,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -402,7 +402,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -433,28 +433,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -462,7 +462,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -470,7 +470,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -478,21 +478,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -501,21 +501,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -525,7 +525,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -535,39 +535,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -617,7 +617,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -631,7 +631,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -642,7 +642,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/TwistWithCovarianceStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/TwistWithCovarianceStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class TwistWithCovarianceStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/TwistWithCovarianceStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="TwistWithCovarianceStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='twist'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/TwistWithCovariance twist]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TwistWithCovariance twist]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TwistWithCovarianceStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.TwistWithCovariance? @twist = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TwistWithCovarianceStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/TwistWithCovariance twist]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TwistWithCovariance twist]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.TwistWithCovariance Twist { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new TwistWithCovarianceStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/TwistWithCovariance twist]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TwistWithCovariance twist]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.TwistWithCovariance.Priv Twist;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Vector3.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Vector3.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Vector3 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Vector3";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -50,7 +50,7 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 z]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Vector3(
             double @x = 0d,
             double @y = 0d,
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Vector3(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.X = priv.X;
@@ -82,32 +82,32 @@ namespace Rosidl.Messages.Geometry
         /// Originally defined as: <c><![CDATA[float64 x]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double X { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 y]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Y { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64 z]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Z { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.X = this.X;
@@ -116,49 +116,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Vector3(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -189,21 +189,21 @@ namespace Rosidl.Messages.Geometry
             public double Z;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -211,7 +211,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -219,28 +219,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -250,7 +250,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -260,18 +260,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -402,28 +402,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -431,7 +431,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -439,7 +439,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -447,21 +447,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -470,21 +470,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -494,7 +494,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -504,39 +504,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -547,7 +547,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -558,7 +558,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -572,7 +572,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -586,7 +586,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -600,7 +600,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -611,7 +611,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Vector3Stamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Vector3Stamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Vector3Stamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Vector3Stamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="Vector3Stamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='vector'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 vector]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 vector]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Vector3Stamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Vector3? @vector = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Vector3Stamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 vector]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 vector]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Vector { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Vector3Stamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 vector]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 vector]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Vector;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Wrench.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/Wrench.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class Wrench : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/Wrench";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="Wrench"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='force'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 force]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 force]]></c>
         /// </param>
         /// <param name='torque'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 torque]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 torque]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Wrench(
             global::Rosidl.Messages.Geometry.Vector3? @force = null,
             global::Rosidl.Messages.Geometry.Vector3? @torque = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Wrench(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Force = new global::Rosidl.Messages.Geometry.Vector3(in priv.Force, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 force]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 force]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Force { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 torque]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 torque]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 Torque { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Force.WriteTo(ref priv.Force, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Wrench(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 force]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 force]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Force;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 torque]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 torque]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv Torque;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/WrenchStamped.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Geometry/Messages/WrenchStamped.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Geometry
     internal unsafe partial class WrenchStamped : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "geometry_msgs/msg/WrenchStamped";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -41,13 +41,13 @@ namespace Rosidl.Messages.Geometry
         /// Create a new instance of <see cref="WrenchStamped"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='wrench'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Wrench wrench]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Wrench wrench]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public WrenchStamped(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Wrench? @wrench = null
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Geometry
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public WrenchStamped(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -73,28 +73,28 @@ namespace Rosidl.Messages.Geometry
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Wrench wrench]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Wrench wrench]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Wrench Wrench { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Geometry
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new WrenchStamped(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,31 +160,31 @@ namespace Rosidl.Messages.Geometry
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Wrench wrench]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Wrench wrench]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Wrench.Priv Wrench;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -200,28 +200,28 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -231,7 +231,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -241,18 +241,18 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -262,21 +262,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -351,7 +351,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -382,28 +382,28 @@ namespace Rosidl.Messages.Geometry
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -419,7 +419,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -427,21 +427,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -474,7 +474,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -484,39 +484,39 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -552,7 +552,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -566,7 +566,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -591,7 +591,7 @@ namespace Rosidl.Messages.Geometry
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/BatteryState.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/BatteryState.cs
@@ -20,11 +20,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class BatteryState : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/BatteryState";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -38,7 +38,7 @@ namespace Rosidl.Messages.Sensor
         /// Create a new instance of <see cref="BatteryState"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='voltage'>
         /// Voltage in Volts (Mandatory)
@@ -101,7 +101,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[string serial_number]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public BatteryState(
             global::Rosidl.Messages.Std.Header? @header = null,
             float @voltage = 0f,
@@ -146,7 +146,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public BatteryState(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -283,10 +283,10 @@ namespace Rosidl.Messages.Sensor
         public const byte POWER_SUPPLY_TECHNOLOGY_LIMN = 6;
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -296,7 +296,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 voltage]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Voltage { get; set; }
         
         /// <summary>
@@ -306,7 +306,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 temperature]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Temperature { get; set; }
         
         /// <summary>
@@ -316,7 +316,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 current]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Current { get; set; }
         
         /// <summary>
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 charge]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Charge { get; set; }
         
         /// <summary>
@@ -336,7 +336,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 capacity]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Capacity { get; set; }
         
         /// <summary>
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 design_capacity]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float DesignCapacity { get; set; }
         
         /// <summary>
@@ -356,7 +356,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 percentage]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Percentage { get; set; }
         
         /// <summary>
@@ -366,7 +366,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 power_supply_status]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte PowerSupplyStatus { get; set; }
         
         /// <summary>
@@ -376,7 +376,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 power_supply_health]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte PowerSupplyHealth { get; set; }
         
         /// <summary>
@@ -386,7 +386,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 power_supply_technology]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte PowerSupplyTechnology { get; set; }
         
         /// <summary>
@@ -396,7 +396,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[bool present]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public bool Present { get; set; }
         
         /// <summary>
@@ -406,7 +406,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32[] cell_voltage]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float[] CellVoltage { get; set; }
         
         /// <summary>
@@ -416,7 +416,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32[] cell_temperature]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float[] CellTemperature { get; set; }
         
         /// <summary>
@@ -426,7 +426,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string location]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string Location { get; set; }
         
         /// <summary>
@@ -436,18 +436,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string serial_number]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string SerialNumber { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -469,49 +469,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new BatteryState(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -524,7 +524,7 @@ namespace Rosidl.Messages.Sensor
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -649,21 +649,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.CString SerialNumber;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -671,7 +671,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -679,28 +679,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -710,7 +710,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -720,18 +720,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -755,21 +755,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -780,7 +780,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -791,7 +791,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -805,7 +805,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -819,7 +819,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -833,7 +833,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -844,7 +844,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -872,28 +872,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -901,7 +901,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -909,7 +909,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -917,21 +917,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -940,21 +940,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -964,7 +964,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -974,39 +974,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -1017,7 +1017,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -1028,7 +1028,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1042,7 +1042,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1056,7 +1056,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -1070,7 +1070,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -1081,7 +1081,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/CameraInfo.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/CameraInfo.cs
@@ -45,11 +45,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class CameraInfo : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/CameraInfo";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -64,7 +64,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// Header timestamp should be acquisition time of image
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='height'>
         /// The image dimensions with which the camera was calibrated.
@@ -116,10 +116,10 @@ namespace Rosidl.Messages.Sensor
         /// regardless of binning settings.
         /// The default setting of roi (all values 0) is considered the same as
         /// full resolution (roi.width = width, roi.height = height).
-        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/RegionOfInterest roi]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/msg/RegionOfInterest roi]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public CameraInfo(
             global::Rosidl.Messages.Std.Header? @header = null,
             uint @height = 0,
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public CameraInfo(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -200,10 +200,10 @@ namespace Rosidl.Messages.Sensor
         /// Header timestamp should be acquisition time of image
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -214,14 +214,14 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 height]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Height { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[uint32 width]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Width { get; set; }
         
         /// <summary>
@@ -233,7 +233,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string distortion_model]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string DistortionModel { get; set; }
         
         /// <summary>
@@ -244,7 +244,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[] d]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] D { get; set; }
         
         private double[] __backingField__K;
@@ -256,7 +256,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[9] k]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] K
         {
             get
@@ -279,7 +279,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[9] r]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] R
         {
             get
@@ -302,7 +302,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[12] p]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] P
         {
             get
@@ -328,14 +328,14 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 binning_x]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint BinningX { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[uint32 binning_y]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint BinningY { get; set; }
         
         /// <summary>
@@ -347,21 +347,21 @@ namespace Rosidl.Messages.Sensor
         /// full resolution (roi.width = width, roi.height = height).
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[sensor_msgs/RegionOfInterest roi]]></c>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/msg/RegionOfInterest roi]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Sensor.RegionOfInterest Roi { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -378,49 +378,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new CameraInfo(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -461,7 +461,7 @@ namespace Rosidl.Messages.Sensor
             /// Header timestamp should be acquisition time of image
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -507,7 +507,7 @@ namespace Rosidl.Messages.Sensor
             /// Originally defined as: <c><![CDATA[float64[9] k]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> K
             {
                 get
@@ -525,7 +525,7 @@ namespace Rosidl.Messages.Sensor
             /// Originally defined as: <c><![CDATA[float64[9] r]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> R
             {
                 get
@@ -543,7 +543,7 @@ namespace Rosidl.Messages.Sensor
             /// Originally defined as: <c><![CDATA[float64[12] p]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> P
             {
                 get
@@ -579,26 +579,26 @@ namespace Rosidl.Messages.Sensor
             /// full resolution (roi.width = width, roi.height = height).
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[sensor_msgs/RegionOfInterest roi]]></c>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/msg/RegionOfInterest roi]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Sensor.RegionOfInterest.Priv Roi;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -606,7 +606,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -614,28 +614,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -645,7 +645,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -655,18 +655,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -695,21 +695,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -720,7 +720,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -731,7 +731,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -745,7 +745,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -759,7 +759,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -773,7 +773,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -784,7 +784,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -837,28 +837,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -866,7 +866,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -874,7 +874,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -882,21 +882,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -905,21 +905,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -929,7 +929,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -939,39 +939,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -982,7 +982,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -993,7 +993,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1007,7 +1007,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1021,7 +1021,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -1035,7 +1035,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -1046,7 +1046,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/ChannelFloat32.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/ChannelFloat32.cs
@@ -38,11 +38,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class ChannelFloat32 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/ChannelFloat32";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -66,7 +66,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[float32[] values]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ChannelFloat32(
             string @name = "",
             float[]? @values = null
@@ -83,7 +83,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ChannelFloat32(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Name = global::Rosidl.Runtime.Interop.StringMarshal.CreatePooledString(priv.Name.AsSpan(), textEncoding);
@@ -99,7 +99,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string name]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string Name { get; set; }
         
         /// <summary>
@@ -110,18 +110,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32[] values]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float[] Values { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Name.CopyFrom(this.Name, textEncoding);
@@ -129,49 +129,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new ChannelFloat32(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -220,21 +220,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.FloatSequence Values;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -242,7 +242,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -250,28 +250,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -281,7 +281,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -291,18 +291,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -312,21 +312,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -348,7 +348,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -362,7 +362,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -376,7 +376,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -390,7 +390,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -401,7 +401,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -447,28 +447,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -476,7 +476,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -484,7 +484,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -492,21 +492,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -515,21 +515,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -539,7 +539,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -549,39 +549,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -592,7 +592,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -617,7 +617,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -631,7 +631,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -645,7 +645,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -656,7 +656,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/CompressedImage.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/CompressedImage.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class CompressedImage : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/CompressedImage";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -42,7 +42,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// Header timestamp should be acquisition time of image
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='format'>
         /// Specifies the format of the data
@@ -53,7 +53,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[uint8[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public CompressedImage(
             global::Rosidl.Messages.Std.Header? @header = null,
             string @format = "",
@@ -72,7 +72,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public CompressedImage(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -85,10 +85,10 @@ namespace Rosidl.Messages.Sensor
         /// Header timestamp should be acquisition time of image
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -98,7 +98,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string format]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string Format { get; set; }
         
         /// <summary>
@@ -108,18 +108,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -128,49 +128,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new CompressedImage(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -189,7 +189,7 @@ namespace Rosidl.Messages.Sensor
             /// Header timestamp should be acquisition time of image
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -210,21 +210,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.UInt8Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -232,7 +232,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -240,28 +240,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -271,7 +271,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -281,18 +281,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -303,21 +303,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -328,7 +328,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -339,7 +339,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -353,7 +353,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -367,7 +367,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -381,7 +381,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -392,7 +392,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -423,28 +423,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -452,7 +452,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -460,7 +460,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -468,21 +468,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -491,21 +491,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -515,7 +515,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -525,39 +525,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -568,7 +568,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -579,7 +579,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -593,7 +593,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -607,7 +607,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -621,7 +621,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -632,7 +632,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Illuminance.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Illuminance.cs
@@ -35,11 +35,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class Illuminance : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/Illuminance";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -54,7 +54,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// timestamp is the time the illuminance was measured
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='illuminance'>
         /// Measurement of the Photometric Illuminance in Lux.
@@ -65,7 +65,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[float64 variance]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Illuminance(
             global::Rosidl.Messages.Std.Header? @header = null,
             double @illuminance = 0d,
@@ -84,7 +84,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Illuminance(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -97,10 +97,10 @@ namespace Rosidl.Messages.Sensor
         /// timestamp is the time the illuminance was measured
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -110,7 +110,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 illuminance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Illuminance_ { get; set; }
         
         /// <summary>
@@ -120,18 +120,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 variance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Variance { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -140,49 +140,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Illuminance(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -213,7 +213,7 @@ namespace Rosidl.Messages.Sensor
             /// timestamp is the time the illuminance was measured
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -234,21 +234,21 @@ namespace Rosidl.Messages.Sensor
             public double Variance;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -256,7 +256,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -264,28 +264,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -295,7 +295,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -305,18 +305,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -327,21 +327,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -352,7 +352,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -363,7 +363,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -377,7 +377,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -391,7 +391,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -405,7 +405,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -416,7 +416,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -459,28 +459,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -488,7 +488,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -496,7 +496,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -504,21 +504,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -527,21 +527,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -551,7 +551,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -561,39 +561,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -604,7 +604,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -615,7 +615,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -629,7 +629,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -643,7 +643,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -657,7 +657,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -668,7 +668,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Image.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Image.cs
@@ -24,11 +24,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class Image : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/Image";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -43,7 +43,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// Header timestamp should be acquisition time of image
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='height'>
         /// image height, that is, number of rows
@@ -70,7 +70,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[uint8[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Image(
             global::Rosidl.Messages.Std.Header? @header = null,
             uint @height = 0,
@@ -97,7 +97,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Image(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -114,10 +114,10 @@ namespace Rosidl.Messages.Sensor
         /// Header timestamp should be acquisition time of image
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -127,7 +127,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 height]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Height { get; set; }
         
         /// <summary>
@@ -137,7 +137,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 width]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Width { get; set; }
         
         /// <summary>
@@ -147,7 +147,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string encoding]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string Encoding { get; set; }
         
         /// <summary>
@@ -157,7 +157,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 is_bigendian]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte IsBigendian { get; set; }
         
         /// <summary>
@@ -167,7 +167,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 step]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Step { get; set; }
         
         /// <summary>
@@ -177,18 +177,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -201,49 +201,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Image(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -263,7 +263,7 @@ namespace Rosidl.Messages.Sensor
             /// Header timestamp should be acquisition time of image
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -316,21 +316,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.UInt8Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -338,7 +338,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -346,28 +346,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -377,7 +377,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -387,18 +387,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -413,21 +413,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -438,7 +438,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -449,7 +449,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -477,7 +477,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -491,7 +491,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -502,7 +502,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -534,28 +534,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -563,7 +563,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -571,7 +571,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -579,21 +579,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -602,21 +602,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -626,7 +626,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -636,39 +636,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -679,7 +679,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -690,7 +690,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -704,7 +704,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -718,7 +718,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -732,7 +732,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -743,7 +743,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Imu.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Imu.cs
@@ -35,11 +35,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class Imu : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/Imu";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -53,31 +53,31 @@ namespace Rosidl.Messages.Sensor
         /// Create a new instance of <see cref="Imu"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='orientation'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion orientation]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion orientation]]></c>
         /// </param>
         /// <param name='orientationCovariance'>
         /// Row major about x, y, z axes
         /// <para>(originally defined as: <c><![CDATA[float64[9] orientation_covariance]]></c>)</para>
         /// </param>
         /// <param name='angularVelocity'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular_velocity]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular_velocity]]></c>
         /// </param>
         /// <param name='angularVelocityCovariance'>
         /// Row major about x, y, z axes
         /// <para>(originally defined as: <c><![CDATA[float64[9] angular_velocity_covariance]]></c>)</para>
         /// </param>
         /// <param name='linearAcceleration'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear_acceleration]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear_acceleration]]></c>
         /// </param>
         /// <param name='linearAccelerationCovariance'>
         /// Row major x, y z
         /// <para>(originally defined as: <c><![CDATA[float64[9] linear_acceleration_covariance]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Imu(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Quaternion? @orientation = null,
@@ -130,7 +130,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Imu(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -144,17 +144,17 @@ namespace Rosidl.Messages.Sensor
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion orientation]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion orientation]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Quaternion Orientation { get; set; }
         
         private double[] __backingField__OrientationCovariance;
@@ -166,7 +166,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[9] orientation_covariance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] OrientationCovariance
         {
             get
@@ -181,10 +181,10 @@ namespace Rosidl.Messages.Sensor
         }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular_velocity]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular_velocity]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 AngularVelocity { get; set; }
         
         private double[] __backingField__AngularVelocityCovariance;
@@ -196,7 +196,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[9] angular_velocity_covariance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] AngularVelocityCovariance
         {
             get
@@ -211,10 +211,10 @@ namespace Rosidl.Messages.Sensor
         }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear_acceleration]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear_acceleration]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 LinearAcceleration { get; set; }
         
         private double[] __backingField__LinearAccelerationCovariance;
@@ -226,7 +226,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[9] linear_acceleration_covariance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] LinearAccelerationCovariance
         {
             get
@@ -241,14 +241,14 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -261,49 +261,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Imu(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -331,12 +331,12 @@ namespace Rosidl.Messages.Sensor
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Quaternion orientation]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Quaternion orientation]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Quaternion.Priv Orientation;
             
@@ -349,7 +349,7 @@ namespace Rosidl.Messages.Sensor
             /// Originally defined as: <c><![CDATA[float64[9] orientation_covariance]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> OrientationCovariance
             {
                 get
@@ -359,7 +359,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 angular_velocity]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 angular_velocity]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv AngularVelocity;
             
@@ -372,7 +372,7 @@ namespace Rosidl.Messages.Sensor
             /// Originally defined as: <c><![CDATA[float64[9] angular_velocity_covariance]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> AngularVelocityCovariance
             {
                 get
@@ -382,7 +382,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 linear_acceleration]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 linear_acceleration]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Vector3.Priv LinearAcceleration;
             
@@ -395,7 +395,7 @@ namespace Rosidl.Messages.Sensor
             /// Originally defined as: <c><![CDATA[float64[9] linear_acceleration_covariance]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> LinearAccelerationCovariance
             {
                 get
@@ -405,21 +405,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -427,7 +427,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -435,28 +435,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -466,7 +466,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -476,18 +476,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -512,21 +512,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -537,7 +537,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -548,7 +548,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -562,7 +562,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -576,7 +576,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -590,7 +590,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -601,7 +601,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -644,28 +644,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -673,7 +673,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -681,7 +681,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -689,21 +689,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -712,21 +712,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -736,7 +736,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -746,39 +746,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -789,7 +789,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -800,7 +800,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -814,7 +814,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -828,7 +828,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -842,7 +842,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -853,7 +853,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/JointState.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/JointState.cs
@@ -40,11 +40,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class JointState : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/JointState";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -58,7 +58,7 @@ namespace Rosidl.Messages.Sensor
         /// Create a new instance of <see cref="JointState"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='name'>
         /// Originally defined as: <c><![CDATA[string[] name]]></c>
@@ -73,7 +73,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[] effort]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public JointState(
             global::Rosidl.Messages.Std.Header? @header = null,
             string[]? @name = null,
@@ -96,7 +96,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public JointState(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -115,49 +115,49 @@ namespace Rosidl.Messages.Sensor
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[string[] name]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string[] Name { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64[] position]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] Position { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64[] velocity]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] Velocity { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float64[] effort]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] Effort { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -175,49 +175,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new JointState(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -250,7 +250,7 @@ namespace Rosidl.Messages.Sensor
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -275,21 +275,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.DoubleSequence Effort;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -297,7 +297,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -305,28 +305,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -336,7 +336,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -346,18 +346,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -370,21 +370,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -395,7 +395,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -406,7 +406,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -420,7 +420,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -448,7 +448,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -459,7 +459,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -507,28 +507,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -536,7 +536,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -544,7 +544,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -552,21 +552,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -575,21 +575,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -599,7 +599,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -609,39 +609,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -652,7 +652,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -663,7 +663,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -677,7 +677,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -691,7 +691,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -705,7 +705,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -716,7 +716,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Joy.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Joy.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class Joy : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/Joy";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -42,7 +42,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// The timestamp is the time at which data is received from the joystick.
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='axes'>
         /// The axes measurements from a joystick.
@@ -53,7 +53,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[int32[] buttons]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Joy(
             global::Rosidl.Messages.Std.Header? @header = null,
             float[]? @axes = null,
@@ -72,7 +72,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Joy(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -85,10 +85,10 @@ namespace Rosidl.Messages.Sensor
         /// The timestamp is the time at which data is received from the joystick.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -98,7 +98,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32[] axes]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float[] Axes { get; set; }
         
         /// <summary>
@@ -108,18 +108,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[int32[] buttons]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public int[] Buttons { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -128,49 +128,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Joy(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -189,7 +189,7 @@ namespace Rosidl.Messages.Sensor
             /// The timestamp is the time at which data is received from the joystick.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -210,21 +210,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.Int32Sequence Buttons;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -232,7 +232,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -240,28 +240,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -271,7 +271,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -281,18 +281,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -303,21 +303,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -328,7 +328,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -339,7 +339,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -353,7 +353,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -367,7 +367,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -381,7 +381,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -392,7 +392,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -423,28 +423,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -452,7 +452,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -460,7 +460,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -468,21 +468,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -491,21 +491,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -515,7 +515,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -525,39 +525,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -568,7 +568,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -579,7 +579,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -593,7 +593,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -607,7 +607,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -621,7 +621,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -632,7 +632,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/JoyFeedback.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/JoyFeedback.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class JoyFeedback : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/JoyFeedback";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -54,7 +54,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[float32 intensity]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public JoyFeedback(
             byte @type = 0,
             byte @id = 0,
@@ -73,7 +73,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public JoyFeedback(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Type = priv.Type;
@@ -104,7 +104,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 type]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte Type { get; set; }
         
         /// <summary>
@@ -115,7 +115,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 id]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte Id { get; set; }
         
         /// <summary>
@@ -126,18 +126,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 intensity]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Intensity { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Type = this.Type;
@@ -146,49 +146,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new JoyFeedback(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -227,21 +227,21 @@ namespace Rosidl.Messages.Sensor
             public float Intensity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -249,7 +249,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -257,28 +257,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -288,7 +288,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -298,18 +298,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -320,21 +320,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -345,7 +345,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -356,7 +356,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -370,7 +370,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -384,7 +384,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -398,7 +398,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -409,7 +409,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -440,28 +440,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -469,7 +469,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -477,7 +477,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -485,21 +485,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -508,21 +508,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -532,7 +532,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -542,39 +542,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -585,7 +585,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -596,7 +596,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -610,7 +610,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -624,7 +624,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -638,7 +638,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -649,7 +649,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/JoyFeedbackArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/JoyFeedbackArray.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class JoyFeedbackArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/JoyFeedbackArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -42,10 +42,10 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='array'>
         /// This message publishes values for multiple feedback at once.
-        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/JoyFeedback[] array]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/msg/JoyFeedback[] array]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public JoyFeedbackArray(
             global::Rosidl.Messages.Sensor.JoyFeedback[]? @array = null
         )
@@ -60,7 +60,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public JoyFeedbackArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Array = new global::Rosidl.Messages.Sensor.JoyFeedback[priv.Array.Size];
@@ -76,21 +76,21 @@ namespace Rosidl.Messages.Sensor
         /// This message publishes values for multiple feedback at once.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[sensor_msgs/JoyFeedback[] array]]></c>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/msg/JoyFeedback[] array]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Sensor.JoyFeedback[] Array { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Array = new global::Rosidl.Messages.Sensor.JoyFeedback.PrivSequence(this.Array.Length);
@@ -102,49 +102,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new JoyFeedbackArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -163,26 +163,26 @@ namespace Rosidl.Messages.Sensor
             /// This message publishes values for multiple feedback at once.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[sensor_msgs/JoyFeedback[] array]]></c>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/msg/JoyFeedback[] array]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Sensor.JoyFeedback.PrivSequence Array;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -190,7 +190,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -198,28 +198,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -229,7 +229,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -239,18 +239,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -259,21 +259,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -295,7 +295,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -309,7 +309,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -323,7 +323,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -348,7 +348,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -379,28 +379,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -416,7 +416,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -424,21 +424,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -447,21 +447,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -471,7 +471,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -481,39 +481,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -524,7 +524,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -535,7 +535,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -549,7 +549,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -563,7 +563,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -577,7 +577,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -588,7 +588,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/LaserEcho.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/LaserEcho.cs
@@ -24,11 +24,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class LaserEcho : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/LaserEcho";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -46,7 +46,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[float32[] echoes]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LaserEcho(
             float[]? @echoes = null
         )
@@ -61,7 +61,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LaserEcho(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Echoes = priv.Echoes.AsSpan().ToArray();
@@ -75,67 +75,67 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32[] echoes]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float[] Echoes { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Echoes.CopyFrom(this.Echoes);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new LaserEcho(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -160,21 +160,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.FloatSequence Echoes;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -182,7 +182,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -190,28 +190,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -221,7 +221,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -231,18 +231,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -251,21 +251,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -276,7 +276,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -287,7 +287,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -301,7 +301,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -315,7 +315,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -329,7 +329,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -372,28 +372,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -401,7 +401,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -409,7 +409,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -417,21 +417,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -440,21 +440,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -464,7 +464,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -474,39 +474,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -517,7 +517,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -528,7 +528,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -542,7 +542,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -556,7 +556,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -570,7 +570,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -581,7 +581,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/LaserScan.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/LaserScan.cs
@@ -27,11 +27,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class LaserScan : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/LaserScan";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -46,7 +46,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// timestamp in the header is the acquisition time of
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='angleMin'>
         /// start angle of the scan [rad]
@@ -85,7 +85,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[float32[] intensities]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LaserScan(
             global::Rosidl.Messages.Std.Header? @header = null,
             float @angleMin = 0f,
@@ -118,7 +118,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LaserScan(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -138,10 +138,10 @@ namespace Rosidl.Messages.Sensor
         /// timestamp in the header is the acquisition time of
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -151,7 +151,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 angle_min]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float AngleMin { get; set; }
         
         /// <summary>
@@ -161,7 +161,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 angle_max]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float AngleMax { get; set; }
         
         /// <summary>
@@ -171,7 +171,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 angle_increment]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float AngleIncrement { get; set; }
         
         /// <summary>
@@ -181,7 +181,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 time_increment]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float TimeIncrement { get; set; }
         
         /// <summary>
@@ -191,7 +191,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 scan_time]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float ScanTime { get; set; }
         
         /// <summary>
@@ -201,7 +201,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 range_min]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float RangeMin { get; set; }
         
         /// <summary>
@@ -211,7 +211,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 range_max]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float RangeMax { get; set; }
         
         /// <summary>
@@ -221,7 +221,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32[] ranges]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float[] Ranges { get; set; }
         
         /// <summary>
@@ -231,18 +231,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32[] intensities]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float[] Intensities { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -258,49 +258,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new LaserScan(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -323,7 +323,7 @@ namespace Rosidl.Messages.Sensor
             /// timestamp in the header is the acquisition time of
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -400,21 +400,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.FloatSequence Intensities;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -422,7 +422,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -430,28 +430,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -461,7 +461,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -471,18 +471,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -500,21 +500,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -525,7 +525,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -536,7 +536,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -564,7 +564,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -624,28 +624,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -653,7 +653,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -661,7 +661,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -669,21 +669,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -692,21 +692,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -716,7 +716,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -726,39 +726,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -769,7 +769,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -780,7 +780,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -794,7 +794,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -808,7 +808,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -822,7 +822,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -833,7 +833,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/MagneticField.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/MagneticField.cs
@@ -30,11 +30,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class MagneticField : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/MagneticField";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -49,18 +49,18 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// timestamp is the time the
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='magneticField'>
         /// x, y, and z components of the
-        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/Vector3 magnetic_field]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 magnetic_field]]></c>)</para>
         /// </param>
         /// <param name='magneticFieldCovariance'>
         /// Row major about x, y, z axes
         /// <para>(originally defined as: <c><![CDATA[float64[9] magnetic_field_covariance]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MagneticField(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Vector3? @magneticField = null,
@@ -87,7 +87,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MagneticField(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -100,20 +100,20 @@ namespace Rosidl.Messages.Sensor
         /// timestamp is the time the
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
         /// x, y, and z components of the
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 magnetic_field]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 magnetic_field]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Vector3 MagneticField_ { get; set; }
         
         private double[] __backingField__MagneticFieldCovariance;
@@ -125,7 +125,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[9] magnetic_field_covariance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] MagneticFieldCovariance
         {
             get
@@ -140,14 +140,14 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -156,49 +156,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new MagneticField(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -224,7 +224,7 @@ namespace Rosidl.Messages.Sensor
             /// timestamp is the time the
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -232,7 +232,7 @@ namespace Rosidl.Messages.Sensor
             /// x, y, and z components of the
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Vector3 magnetic_field]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Vector3 magnetic_field]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Geometry.Vector3.Priv MagneticField_;
             
@@ -245,7 +245,7 @@ namespace Rosidl.Messages.Sensor
             /// Originally defined as: <c><![CDATA[float64[9] magnetic_field_covariance]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> MagneticFieldCovariance
             {
                 get
@@ -255,21 +255,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -277,7 +277,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -285,28 +285,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -316,7 +316,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -326,18 +326,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -352,21 +352,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -377,7 +377,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -388,7 +388,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -402,7 +402,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -416,7 +416,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -430,7 +430,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -441,7 +441,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -479,28 +479,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -508,7 +508,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -524,21 +524,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -547,21 +547,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -571,7 +571,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -581,39 +581,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -624,7 +624,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -635,7 +635,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -649,7 +649,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -663,7 +663,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -677,7 +677,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -688,7 +688,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/MultiDOFJointState.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/MultiDOFJointState.cs
@@ -41,11 +41,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class MultiDOFJointState : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/MultiDOFJointState";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -59,22 +59,22 @@ namespace Rosidl.Messages.Sensor
         /// Create a new instance of <see cref="MultiDOFJointState"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='header'>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </param>
         /// <param name='jointNames'>
         /// Originally defined as: <c><![CDATA[string[] joint_names]]></c>
         /// </param>
         /// <param name='transforms'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Transform[] transforms]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Transform[] transforms]]></c>
         /// </param>
         /// <param name='twist'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Twist[] twist]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist[] twist]]></c>
         /// </param>
         /// <param name='wrench'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Wrench[] wrench]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Wrench[] wrench]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MultiDOFJointState(
             global::Rosidl.Messages.Std.Header? @header = null,
             string[]? @jointNames = null,
@@ -97,7 +97,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MultiDOFJointState(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -133,49 +133,49 @@ namespace Rosidl.Messages.Sensor
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[string[] joint_names]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string[] JointNames { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Transform[] transforms]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Transform[] transforms]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Transform[] Transforms { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Twist[] twist]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist[] twist]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Twist[] Twist { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Wrench[] wrench]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Wrench[] wrench]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Wrench[] Wrench { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -210,49 +210,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new MultiDOFJointState(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -286,7 +286,7 @@ namespace Rosidl.Messages.Sensor
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </summary>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -296,36 +296,36 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.CStringSequence JointNames;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Transform[] transforms]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Transform[] transforms]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Transform.PrivSequence Transforms;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Twist[] twist]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Twist[] twist]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Twist.PrivSequence Twist;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Wrench[] wrench]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Wrench[] wrench]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.Wrench.PrivSequence Wrench;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -333,7 +333,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -341,28 +341,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -372,7 +372,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -382,18 +382,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -406,21 +406,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -431,7 +431,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -456,7 +456,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -470,7 +470,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -484,7 +484,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -495,7 +495,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -544,28 +544,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -573,7 +573,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -581,7 +581,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -589,21 +589,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -612,21 +612,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -636,7 +636,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -646,39 +646,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -689,7 +689,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -700,7 +700,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -714,7 +714,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -728,7 +728,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -742,7 +742,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -753,7 +753,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/MultiEchoLaserScan.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/MultiEchoLaserScan.cs
@@ -27,11 +27,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class MultiEchoLaserScan : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/MultiEchoLaserScan";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -46,7 +46,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// timestamp in the header is the acquisition time of
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='angleMin'>
         /// start angle of the scan [rad]
@@ -78,14 +78,14 @@ namespace Rosidl.Messages.Sensor
         /// </param>
         /// <param name='ranges'>
         /// range data [m]
-        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/LaserEcho[] ranges]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/msg/LaserEcho[] ranges]]></c>)</para>
         /// </param>
         /// <param name='intensities'>
         /// intensity data [device-specific units].  If your
-        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/LaserEcho[] intensities]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/msg/LaserEcho[] intensities]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MultiEchoLaserScan(
             global::Rosidl.Messages.Std.Header? @header = null,
             float @angleMin = 0f,
@@ -118,7 +118,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MultiEchoLaserScan(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -150,10 +150,10 @@ namespace Rosidl.Messages.Sensor
         /// timestamp in the header is the acquisition time of
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -163,7 +163,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 angle_min]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float AngleMin { get; set; }
         
         /// <summary>
@@ -173,7 +173,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 angle_max]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float AngleMax { get; set; }
         
         /// <summary>
@@ -183,7 +183,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 angle_increment]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float AngleIncrement { get; set; }
         
         /// <summary>
@@ -193,7 +193,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 time_increment]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float TimeIncrement { get; set; }
         
         /// <summary>
@@ -203,7 +203,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 scan_time]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float ScanTime { get; set; }
         
         /// <summary>
@@ -213,7 +213,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 range_min]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float RangeMin { get; set; }
         
         /// <summary>
@@ -223,38 +223,38 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 range_max]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float RangeMax { get; set; }
         
         /// <summary>
         /// range data [m]
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[sensor_msgs/LaserEcho[] ranges]]></c>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/msg/LaserEcho[] ranges]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Sensor.LaserEcho[] Ranges { get; set; }
         
         /// <summary>
         /// intensity data [device-specific units].  If your
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[sensor_msgs/LaserEcho[] intensities]]></c>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/msg/LaserEcho[] intensities]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Sensor.LaserEcho[] Intensities { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -282,49 +282,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new MultiEchoLaserScan(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -347,7 +347,7 @@ namespace Rosidl.Messages.Sensor
             /// timestamp in the header is the acquisition time of
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -411,7 +411,7 @@ namespace Rosidl.Messages.Sensor
             /// range data [m]
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[sensor_msgs/LaserEcho[] ranges]]></c>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/msg/LaserEcho[] ranges]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Sensor.LaserEcho.PrivSequence Ranges;
             
@@ -419,26 +419,26 @@ namespace Rosidl.Messages.Sensor
             /// intensity data [device-specific units].  If your
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[sensor_msgs/LaserEcho[] intensities]]></c>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/msg/LaserEcho[] intensities]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Sensor.LaserEcho.PrivSequence Intensities;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -446,7 +446,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -454,28 +454,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -485,7 +485,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -495,18 +495,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -524,21 +524,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -549,7 +549,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -560,7 +560,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -574,7 +574,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -588,7 +588,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -602,7 +602,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -613,7 +613,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -648,28 +648,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -677,7 +677,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -685,7 +685,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -693,21 +693,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -716,21 +716,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -740,7 +740,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -750,39 +750,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -793,7 +793,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -804,7 +804,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -818,7 +818,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -832,7 +832,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -846,7 +846,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -857,7 +857,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/NavSatFix.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/NavSatFix.cs
@@ -25,11 +25,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class NavSatFix : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/NavSatFix";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -51,11 +51,11 @@ namespace Rosidl.Messages.Sensor
         /// receiver, usually the location of the antenna.  This is a
         /// Euclidean frame relative to the vehicle, not a reference
         /// ellipsoid.
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='status'>
         /// Satellite fix status information.
-        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/NavSatStatus status]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/msg/NavSatStatus status]]></c>)</para>
         /// </param>
         /// <param name='latitude'>
         /// Latitude [degrees]. Positive is north of equator; negative is south.
@@ -82,7 +82,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 position_covariance_type]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public NavSatFix(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Sensor.NavSatStatus? @status = null,
@@ -118,7 +118,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public NavSatFix(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -162,20 +162,20 @@ namespace Rosidl.Messages.Sensor
         /// ellipsoid.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
         /// Satellite fix status information.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[sensor_msgs/NavSatStatus status]]></c>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/msg/NavSatStatus status]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Sensor.NavSatStatus Status { get; set; }
         
         /// <summary>
@@ -185,7 +185,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 latitude]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Latitude { get; set; }
         
         /// <summary>
@@ -195,7 +195,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 longitude]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Longitude { get; set; }
         
         /// <summary>
@@ -206,7 +206,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 altitude]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Altitude { get; set; }
         
         private double[] __backingField__PositionCovariance;
@@ -222,7 +222,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64[9] position_covariance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] PositionCovariance
         {
             get
@@ -240,18 +240,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 position_covariance_type]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte PositionCovarianceType { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -264,49 +264,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new NavSatFix(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -334,7 +334,7 @@ namespace Rosidl.Messages.Sensor
             /// ellipsoid.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -342,7 +342,7 @@ namespace Rosidl.Messages.Sensor
             /// Satellite fix status information.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[sensor_msgs/NavSatStatus status]]></c>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/msg/NavSatStatus status]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Sensor.NavSatStatus.Priv Status;
             
@@ -384,7 +384,7 @@ namespace Rosidl.Messages.Sensor
             /// Originally defined as: <c><![CDATA[float64[9] position_covariance]]></c>
             /// </remarks>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public global::System.Span<double> PositionCovariance
             {
                 get
@@ -399,21 +399,21 @@ namespace Rosidl.Messages.Sensor
             public byte PositionCovarianceType;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -421,7 +421,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -429,28 +429,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -460,7 +460,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -470,18 +470,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -500,21 +500,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -525,7 +525,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -536,7 +536,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -564,7 +564,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -622,28 +622,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -651,7 +651,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -659,7 +659,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -667,21 +667,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -690,21 +690,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -714,7 +714,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -724,39 +724,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -767,7 +767,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -778,7 +778,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -792,7 +792,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -806,7 +806,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -820,7 +820,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -831,7 +831,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/NavSatStatus.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/NavSatStatus.cs
@@ -27,11 +27,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class NavSatStatus : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/NavSatStatus";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -51,7 +51,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint16 service]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public NavSatStatus(
             sbyte @status = 0,
             ushort @service = 0
@@ -68,7 +68,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public NavSatStatus(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Status = priv.Status;
@@ -135,25 +135,25 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[int8 status]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public sbyte Status { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[uint16 service]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ushort Service { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Status = this.Status;
@@ -161,49 +161,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new NavSatStatus(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -233,21 +233,21 @@ namespace Rosidl.Messages.Sensor
             public ushort Service;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -255,7 +255,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -263,28 +263,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -294,7 +294,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -304,18 +304,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -325,21 +325,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -350,7 +350,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -361,7 +361,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -375,7 +375,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -389,7 +389,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -403,7 +403,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -414,7 +414,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -449,28 +449,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -478,7 +478,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -486,7 +486,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -494,21 +494,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -517,21 +517,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -551,39 +551,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -594,7 +594,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -605,7 +605,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -619,7 +619,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -633,7 +633,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -647,7 +647,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -658,7 +658,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/PointCloud.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/PointCloud.cs
@@ -24,11 +24,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class PointCloud : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/PointCloud";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -43,21 +43,21 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// Time of sensor data acquisition, coordinate frame ID.
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='points'>
         /// Array of 3d points. Each Point32 should be interpreted as a 3d point
         /// in the frame given in the header.
-        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/Point32[] points]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[geometry_msgs/msg/Point32[] points]]></c>)</para>
         /// </param>
         /// <param name='channels'>
         /// Each channel should have the same number of elements as points array,
         /// and the data in each channel should correspond 1:1 with each point.
         /// Channel names in common practice are listed in ChannelFloat32.msg.
-        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/ChannelFloat32[] channels]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/msg/ChannelFloat32[] channels]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PointCloud(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Geometry.Point32[]? @points = null,
@@ -76,7 +76,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PointCloud(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -101,10 +101,10 @@ namespace Rosidl.Messages.Sensor
         /// Time of sensor data acquisition, coordinate frame ID.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -112,10 +112,10 @@ namespace Rosidl.Messages.Sensor
         /// in the frame given in the header.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/Point32[] points]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point32[] points]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.Point32[] Points { get; set; }
         
         /// <summary>
@@ -124,21 +124,21 @@ namespace Rosidl.Messages.Sensor
         /// Channel names in common practice are listed in ChannelFloat32.msg.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[sensor_msgs/ChannelFloat32[] channels]]></c>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/msg/ChannelFloat32[] channels]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Sensor.ChannelFloat32[] Channels { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -159,49 +159,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PointCloud(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -221,7 +221,7 @@ namespace Rosidl.Messages.Sensor
             /// Time of sensor data acquisition, coordinate frame ID.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -230,7 +230,7 @@ namespace Rosidl.Messages.Sensor
             /// in the frame given in the header.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/Point32[] points]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/Point32[] points]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Geometry.Point32.PrivSequence Points;
             
@@ -240,26 +240,26 @@ namespace Rosidl.Messages.Sensor
             /// Channel names in common practice are listed in ChannelFloat32.msg.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[sensor_msgs/ChannelFloat32[] channels]]></c>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/msg/ChannelFloat32[] channels]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Sensor.ChannelFloat32.PrivSequence Channels;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -267,7 +267,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -275,28 +275,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -306,7 +306,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -316,18 +316,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -338,21 +338,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -363,7 +363,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -374,7 +374,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -388,7 +388,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -402,7 +402,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -416,7 +416,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -427,7 +427,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -459,28 +459,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -488,7 +488,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -496,7 +496,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -504,21 +504,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -527,21 +527,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -551,7 +551,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -561,39 +561,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -604,7 +604,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -615,7 +615,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -629,7 +629,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -643,7 +643,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -657,7 +657,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -668,7 +668,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/PointCloud2.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/PointCloud2.cs
@@ -30,11 +30,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class PointCloud2 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/PointCloud2";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -49,7 +49,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// Time of sensor data acquisition, and the coordinate frame ID (for 3d points).
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='height'>
         /// 2D structure of the point cloud. If the cloud is unordered, height is
@@ -61,7 +61,7 @@ namespace Rosidl.Messages.Sensor
         /// </param>
         /// <param name='fields'>
         /// Describes the channels and their layout in the binary data blob.
-        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/PointField[] fields]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/msg/PointField[] fields]]></c>)</para>
         /// </param>
         /// <param name='isBigendian'>
         /// Is this data bigendian?
@@ -84,7 +84,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[bool is_dense]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PointCloud2(
             global::Rosidl.Messages.Std.Header? @header = null,
             uint @height = 0,
@@ -115,7 +115,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PointCloud2(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -141,10 +141,10 @@ namespace Rosidl.Messages.Sensor
         /// Time of sensor data acquisition, and the coordinate frame ID (for 3d points).
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -155,24 +155,24 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 height]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Height { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[uint32 width]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Width { get; set; }
         
         /// <summary>
         /// Describes the channels and their layout in the binary data blob.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[sensor_msgs/PointField[] fields]]></c>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/msg/PointField[] fields]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Sensor.PointField[] Fields { get; set; }
         
         /// <summary>
@@ -182,7 +182,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[bool is_bigendian]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public bool IsBigendian { get; set; }
         
         /// <summary>
@@ -192,7 +192,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 point_step]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint PointStep { get; set; }
         
         /// <summary>
@@ -202,7 +202,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 row_step]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint RowStep { get; set; }
         
         /// <summary>
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte[] Data { get; set; }
         
         /// <summary>
@@ -222,18 +222,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[bool is_dense]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public bool IsDense { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -255,49 +255,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PointCloud2(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -323,7 +323,7 @@ namespace Rosidl.Messages.Sensor
             /// Time of sensor data acquisition, and the coordinate frame ID (for 3d points).
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -345,7 +345,7 @@ namespace Rosidl.Messages.Sensor
             /// Describes the channels and their layout in the binary data blob.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[sensor_msgs/PointField[] fields]]></c>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/msg/PointField[] fields]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Sensor.PointField.PrivSequence Fields;
             
@@ -390,21 +390,21 @@ namespace Rosidl.Messages.Sensor
             public bool IsDense;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -412,7 +412,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -420,28 +420,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -451,7 +451,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -461,18 +461,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -489,21 +489,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -514,7 +514,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -525,7 +525,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -539,7 +539,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -553,7 +553,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -567,7 +567,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -616,28 +616,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -645,7 +645,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -653,7 +653,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -661,21 +661,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -684,21 +684,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -708,7 +708,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -718,39 +718,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -761,7 +761,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -772,7 +772,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -786,7 +786,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -800,7 +800,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -814,7 +814,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -825,7 +825,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/PointField.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/PointField.cs
@@ -24,11 +24,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class PointField : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/PointField";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -58,7 +58,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[uint32 count]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PointField(
             string @name = "",
             uint @offset = 0,
@@ -79,7 +79,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public PointField(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Name = global::Rosidl.Runtime.Interop.StringMarshal.CreatePooledString(priv.Name.AsSpan(), textEncoding);
@@ -140,7 +140,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string name]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string Name { get; set; }
         
         /// <summary>
@@ -150,7 +150,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 offset]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Offset { get; set; }
         
         /// <summary>
@@ -160,7 +160,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 datatype]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte Datatype { get; set; }
         
         /// <summary>
@@ -170,18 +170,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 count]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Count { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Name.CopyFrom(this.Name, textEncoding);
@@ -191,49 +191,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new PointField(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Sensor
             public uint Count;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -304,7 +304,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -312,28 +312,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -343,7 +343,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -353,18 +353,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -376,21 +376,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -401,7 +401,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -412,7 +412,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -426,7 +426,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -440,7 +440,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -454,7 +454,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -465,7 +465,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -497,28 +497,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -526,7 +526,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -534,7 +534,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -542,21 +542,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -565,21 +565,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -599,39 +599,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -642,7 +642,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -653,7 +653,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -667,7 +667,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -681,7 +681,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -695,7 +695,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -706,7 +706,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Range.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Range.cs
@@ -31,11 +31,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class Range : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/Range";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -50,7 +50,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// timestamp in the header is the time the ranger
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='radiationType'>
         /// the type of radiation used by the sensor
@@ -73,7 +73,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[float32 range]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Range(
             global::Rosidl.Messages.Std.Header? @header = null,
             byte @radiationType = 0,
@@ -98,7 +98,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Range(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -128,10 +128,10 @@ namespace Rosidl.Messages.Sensor
         /// timestamp in the header is the time the ranger
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -141,7 +141,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint8 radiation_type]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte RadiationType { get; set; }
         
         /// <summary>
@@ -151,7 +151,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 field_of_view]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float FieldOfView { get; set; }
         
         /// <summary>
@@ -161,7 +161,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 min_range]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float MinRange { get; set; }
         
         /// <summary>
@@ -171,7 +171,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 max_range]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float MaxRange { get; set; }
         
         /// <summary>
@@ -181,18 +181,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float32 range]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Range_ { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -204,49 +204,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Range(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Sensor
             /// timestamp in the header is the time the ranger
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -318,21 +318,21 @@ namespace Rosidl.Messages.Sensor
             public float Range_;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -340,7 +340,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -348,28 +348,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -379,7 +379,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -389,18 +389,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -414,21 +414,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -439,7 +439,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -450,7 +450,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -464,7 +464,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -478,7 +478,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -492,7 +492,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -503,7 +503,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -542,28 +542,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -571,7 +571,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -579,7 +579,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -587,21 +587,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -610,21 +610,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -634,7 +634,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -644,39 +644,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -687,7 +687,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -698,7 +698,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -712,7 +712,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -726,7 +726,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -740,7 +740,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -751,7 +751,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/RegionOfInterest.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/RegionOfInterest.cs
@@ -28,11 +28,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class RegionOfInterest : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/RegionOfInterest";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[bool do_rectify]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public RegionOfInterest(
             uint @xOffset = 0,
             uint @yOffset = 0,
@@ -92,7 +92,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public RegionOfInterest(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.XOffset = priv.XOffset;
@@ -110,7 +110,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 x_offset]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint XOffset { get; set; }
         
         /// <summary>
@@ -120,7 +120,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 y_offset]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint YOffset { get; set; }
         
         /// <summary>
@@ -130,7 +130,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 height]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Height { get; set; }
         
         /// <summary>
@@ -140,7 +140,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[uint32 width]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Width { get; set; }
         
         /// <summary>
@@ -153,18 +153,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[bool do_rectify]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public bool DoRectify { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.XOffset = this.XOffset;
@@ -175,49 +175,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new RegionOfInterest(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -281,21 +281,21 @@ namespace Rosidl.Messages.Sensor
             public bool DoRectify;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -303,7 +303,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -311,28 +311,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -342,7 +342,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -352,18 +352,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -376,21 +376,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -401,7 +401,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -412,7 +412,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -426,7 +426,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -440,7 +440,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -454,7 +454,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -465,7 +465,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -501,28 +501,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -530,7 +530,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -538,7 +538,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -546,21 +546,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -569,21 +569,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -593,7 +593,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -603,39 +603,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -646,7 +646,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -657,7 +657,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -671,7 +671,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -685,7 +685,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -699,7 +699,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -710,7 +710,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/RelativeHumidity.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/RelativeHumidity.cs
@@ -25,11 +25,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class RelativeHumidity : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/RelativeHumidity";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -44,7 +44,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// timestamp of the measurement
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='relativeHumidity'>
         /// Expression of the relative humidity
@@ -55,7 +55,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[float64 variance]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public RelativeHumidity(
             global::Rosidl.Messages.Std.Header? @header = null,
             double @relativeHumidity = 0d,
@@ -74,7 +74,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public RelativeHumidity(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -87,10 +87,10 @@ namespace Rosidl.Messages.Sensor
         /// timestamp of the measurement
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -100,7 +100,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 relative_humidity]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double RelativeHumidity_ { get; set; }
         
         /// <summary>
@@ -110,18 +110,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 variance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Variance { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -130,49 +130,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new RelativeHumidity(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -193,7 +193,7 @@ namespace Rosidl.Messages.Sensor
             /// timestamp of the measurement
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -214,21 +214,21 @@ namespace Rosidl.Messages.Sensor
             public double Variance;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -236,7 +236,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -244,28 +244,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -275,7 +275,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -285,18 +285,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -307,21 +307,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -343,7 +343,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -357,7 +357,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -385,7 +385,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -396,7 +396,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -429,28 +429,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -458,7 +458,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -466,7 +466,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -474,21 +474,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -497,21 +497,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -521,7 +521,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -531,39 +531,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -574,7 +574,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -585,7 +585,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -599,7 +599,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -613,7 +613,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -627,7 +627,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -638,7 +638,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Temperature.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/Temperature.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class Temperature : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/Temperature";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -42,7 +42,7 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// timestamp is the time the temperature was measured
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='temperature'>
         /// Measurement of the Temperature in Degrees Celsius.
@@ -53,7 +53,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[float64 variance]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Temperature(
             global::Rosidl.Messages.Std.Header? @header = null,
             double @temperature = 0d,
@@ -72,7 +72,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Temperature(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -85,10 +85,10 @@ namespace Rosidl.Messages.Sensor
         /// timestamp is the time the temperature was measured
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
@@ -98,7 +98,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 temperature]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Temperature_ { get; set; }
         
         /// <summary>
@@ -108,18 +108,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[float64 variance]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Variance { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -128,49 +128,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Temperature(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -189,7 +189,7 @@ namespace Rosidl.Messages.Sensor
             /// timestamp is the time the temperature was measured
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -210,21 +210,21 @@ namespace Rosidl.Messages.Sensor
             public double Variance;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -232,7 +232,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -240,28 +240,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -271,7 +271,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -281,18 +281,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -303,21 +303,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -328,7 +328,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -339,7 +339,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -353,7 +353,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -367,7 +367,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -381,7 +381,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -392,7 +392,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -423,28 +423,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -452,7 +452,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -460,7 +460,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -468,21 +468,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -491,21 +491,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -515,7 +515,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -525,39 +525,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -568,7 +568,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -579,7 +579,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -593,7 +593,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -607,7 +607,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -621,7 +621,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -632,7 +632,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/TimeReference.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Messages/TimeReference.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class TimeReference : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/msg/TimeReference";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -42,18 +42,18 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='header'>
         /// stamp is system time for which measurement was valid
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/Header header]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
         /// </param>
         /// <param name='timeRef'>
         /// corresponding time from this external source
-        /// <para>(originally defined as: <c><![CDATA[builtin_interfaces/Time time_ref]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[builtin_interfaces/msg/Time time_ref]]></c>)</para>
         /// </param>
         /// <param name='source'>
         /// (optional) name of time source
         /// <para>(originally defined as: <c><![CDATA[string source]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TimeReference(
             global::Rosidl.Messages.Std.Header? @header = null,
             global::Rosidl.Messages.Builtin.Time? @timeRef = null,
@@ -72,7 +72,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TimeReference(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
@@ -85,20 +85,20 @@ namespace Rosidl.Messages.Sensor
         /// stamp is system time for which measurement was valid
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.Header Header { get; set; }
         
         /// <summary>
         /// corresponding time from this external source
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[builtin_interfaces/Time time_ref]]></c>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time time_ref]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Builtin.Time TimeRef { get; set; }
         
         /// <summary>
@@ -108,18 +108,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string source]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string Source { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Header.WriteTo(ref priv.Header, textEncoding);
@@ -128,49 +128,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new TimeReference(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -189,7 +189,7 @@ namespace Rosidl.Messages.Sensor
             /// stamp is system time for which measurement was valid
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.Header.Priv Header;
             
@@ -197,7 +197,7 @@ namespace Rosidl.Messages.Sensor
             /// corresponding time from this external source
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[builtin_interfaces/Time time_ref]]></c>
+            /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time time_ref]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Builtin.Time.Priv TimeRef;
             
@@ -210,21 +210,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.CString Source;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -232,7 +232,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -240,28 +240,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -271,7 +271,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -281,18 +281,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -303,21 +303,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -328,7 +328,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -339,7 +339,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -353,7 +353,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -367,7 +367,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -381,7 +381,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -392,7 +392,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -423,28 +423,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -452,7 +452,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -460,7 +460,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -468,21 +468,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -491,21 +491,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -515,7 +515,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -525,39 +525,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -568,7 +568,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -579,7 +579,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -593,7 +593,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -607,7 +607,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -621,7 +621,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -632,7 +632,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Sensor/Services/SetCameraInfo.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Sensor/Services/SetCameraInfo.cs
@@ -29,11 +29,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class SetCameraInfoService : global::Rosidl.Runtime.IService<SetCameraInfoServiceRequest, SetCameraInfoServiceResponse>
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/srv/SetCameraInfo";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Service);
@@ -60,11 +60,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class SetCameraInfoServiceRequest : global::Rosidl.Runtime.IServiceRequest
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/srv/SetCameraInfo_Request";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -79,10 +79,10 @@ namespace Rosidl.Messages.Sensor
         /// </summary>
         /// <param name='cameraInfo'>
         /// The camera_info to store
-        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/CameraInfo camera_info]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/msg/CameraInfo camera_info]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public SetCameraInfoServiceRequest(
             global::Rosidl.Messages.Sensor.CameraInfo? @cameraInfo = null
         )
@@ -97,7 +97,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public SetCameraInfoServiceRequest(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.CameraInfo = new global::Rosidl.Messages.Sensor.CameraInfo(in priv.CameraInfo, textEncoding);
@@ -108,70 +108,70 @@ namespace Rosidl.Messages.Sensor
         /// The camera_info to store
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[sensor_msgs/CameraInfo camera_info]]></c>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/msg/CameraInfo camera_info]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Sensor.CameraInfo CameraInfo { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.CameraInfo.WriteTo(ref priv.CameraInfo, textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new SetCameraInfoServiceRequest(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -196,26 +196,26 @@ namespace Rosidl.Messages.Sensor
             /// The camera_info to store
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[sensor_msgs/CameraInfo camera_info]]></c>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/msg/CameraInfo camera_info]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Sensor.CameraInfo.Priv CameraInfo;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -223,7 +223,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -231,28 +231,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -262,7 +262,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -272,18 +272,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -292,21 +292,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -317,7 +317,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -328,7 +328,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -342,7 +342,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -356,7 +356,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -370,7 +370,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -381,7 +381,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -418,28 +418,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -447,7 +447,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -455,7 +455,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -463,21 +463,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -486,21 +486,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -510,7 +510,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -520,39 +520,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -563,7 +563,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -574,7 +574,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -588,7 +588,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -602,7 +602,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -616,7 +616,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -627,7 +627,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -655,11 +655,11 @@ namespace Rosidl.Messages.Sensor
     internal unsafe partial class SetCameraInfoServiceResponse : global::Rosidl.Runtime.IServiceResponse
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "sensor_msgs/srv/SetCameraInfo_Response";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -681,7 +681,7 @@ namespace Rosidl.Messages.Sensor
         /// <para>(originally defined as: <c><![CDATA[string status_message]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public SetCameraInfoServiceResponse(
             bool @success = false,
             string @statusMessage = ""
@@ -698,7 +698,7 @@ namespace Rosidl.Messages.Sensor
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public SetCameraInfoServiceResponse(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Success = priv.Success;
@@ -713,7 +713,7 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[bool success]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public bool Success { get; set; }
         
         /// <summary>
@@ -723,18 +723,18 @@ namespace Rosidl.Messages.Sensor
         /// Originally defined as: <c><![CDATA[string status_message]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string StatusMessage { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Success = this.Success;
@@ -742,49 +742,49 @@ namespace Rosidl.Messages.Sensor
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new SetCameraInfoServiceResponse(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -822,21 +822,21 @@ namespace Rosidl.Messages.Sensor
             public global::Rosidl.Runtime.Interop.CString StatusMessage;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -844,7 +844,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -852,28 +852,28 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -883,7 +883,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -893,18 +893,18 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -914,21 +914,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -939,7 +939,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -950,7 +950,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -964,7 +964,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -978,7 +978,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -992,7 +992,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -1003,7 +1003,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -1040,28 +1040,28 @@ namespace Rosidl.Messages.Sensor
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -1069,7 +1069,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -1077,7 +1077,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -1085,21 +1085,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -1108,21 +1108,21 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -1132,7 +1132,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -1142,39 +1142,39 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -1185,7 +1185,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -1196,7 +1196,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1210,7 +1210,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1224,7 +1224,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -1238,7 +1238,7 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -1249,13 +1249,727 @@ namespace Rosidl.Messages.Sensor
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
                 if (!ret)
                 {
                     throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// This service requests that a camera stores the given CameraInfo as that
+    /// camera's calibration information.
+    /// 
+    /// The width and height in the camera_info field should match what the
+    /// camera is currently outputting on its camera_info topic, and the camera
+    /// will assume that the region of the imager that is being referred to is
+    /// the region that the camera is currently capturing.
+    /// </summary>
+    /// <remarks>
+    /// Message interface definition for <c>sensor_msgs/srv/SetCameraInfo_Event</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("sensor_msgs/srv/SetCameraInfo_Event")]
+    internal unsafe partial class SetCameraInfoServiceEvent : global::Rosidl.Runtime.IServiceEvent
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "sensor_msgs/srv/SetCameraInfo_Event";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__sensor_msgs__srv__SetCameraInfo_Event")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="SetCameraInfoServiceEvent"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='info'>
+        /// Event info
+        /// Contains event type, timestamp, and request ID
+        /// <para>(originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>)</para>
+        /// </param>
+        /// <param name='request'>
+        /// The actual request content sent or received
+        /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/srv/SetCameraInfo_Request[<=1] request]]></c>)</para>
+        /// </param>
+        /// <param name='response'>
+        /// The actual response content sent or received
+        /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// <para>(originally defined as: <c><![CDATA[sensor_msgs/srv/SetCameraInfo_Response[<=1] response]]></c>)</para>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public SetCameraInfoServiceEvent(
+            global::Rosidl.Messages.Service.ServiceEventInfo? @info = null,
+            global::Rosidl.Messages.Sensor.SetCameraInfoServiceRequest[]? @request = null,
+            global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse[]? @response = null
+        )
+        {
+            Info = @info ?? new global::Rosidl.Messages.Service.ServiceEventInfo();
+            Request = @request ?? global::System.Array.Empty<global::Rosidl.Messages.Sensor.SetCameraInfoServiceRequest>();
+            Response = @response ?? global::System.Array.Empty<global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse>();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="SetCameraInfoServiceEvent"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public SetCameraInfoServiceEvent(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Info = new global::Rosidl.Messages.Service.ServiceEventInfo(in priv.Info, textEncoding);
+        
+            this.Request = new global::Rosidl.Messages.Sensor.SetCameraInfoServiceRequest[priv.Request.Size];
+            var Request_span = priv.Request.AsSpan();
+            for (int __i = 0; __i < this.Request.Length; __i++)
+            {
+                this.Request[__i] = new global::Rosidl.Messages.Sensor.SetCameraInfoServiceRequest(in Request_span[__i], textEncoding);
+            }
+        
+            this.Response = new global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse[priv.Response.Size];
+            var Response_span = priv.Response.AsSpan();
+            for (int __i = 0; __i < this.Response.Length; __i++)
+            {
+                this.Response[__i] = new global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse(in Response_span[__i], textEncoding);
+            }
+        }
+        
+        
+        /// <summary>
+        /// Event info
+        /// Contains event type, timestamp, and request ID
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Service.ServiceEventInfo Info { get; set; }
+        
+        private global::Rosidl.Messages.Sensor.SetCameraInfoServiceRequest[] __backingField__Request;
+        
+        /// <summary>
+        /// The actual request content sent or received
+        /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/srv/SetCameraInfo_Request[<=1] request]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Sensor.SetCameraInfoServiceRequest[] Request
+        {
+            get
+            {
+                return __backingField__Request;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__Request))]
+            set
+            {
+                __backingField__Request = value.Length <= 1 ? value : throw new global::System.ArgumentException("Size of the array or string 'Request' must be less or equal than 1.");
+            }
+        }
+        
+        private global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse[] __backingField__Response;
+        
+        /// <summary>
+        /// The actual response content sent or received
+        /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[sensor_msgs/srv/SetCameraInfo_Response[<=1] response]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse[] Response
+        {
+            get
+            {
+                return __backingField__Response;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__Response))]
+            set
+            {
+                __backingField__Response = value.Length <= 1 ? value : throw new global::System.ArgumentException("Size of the array or string 'Response' must be less or equal than 1.");
+            }
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Info.WriteTo(ref priv.Info, textEncoding);
+            
+            priv.Request = new global::Rosidl.Messages.Sensor.SetCameraInfoServiceRequest.PrivSequence(this.Request.Length);
+            var Request_span = priv.Request.AsSpan();
+            for (int __i = 0; __i < this.Request.Length; __i++)
+            {
+                this.Request[__i].WriteTo(ref Request_span[__i], textEncoding);
+            }
+            
+            priv.Response = new global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse.PrivSequence(this.Response.Length);
+            var Response_span = priv.Response.AsSpan();
+            for (int __i = 0; __i < this.Response.Length; __i++)
+            {
+                this.Response[__i].WriteTo(ref Response_span[__i], textEncoding);
+            }
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new SetCameraInfoServiceEvent(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// This service requests that a camera stores the given CameraInfo as that
+        /// camera's calibration information.
+        /// 
+        /// The width and height in the camera_info field should match what the
+        /// camera is currently outputting on its camera_info topic, and the camera
+        /// will assume that the region of the imager that is being referred to is
+        /// the region that the camera is currently capturing.
+        /// </summary>
+        /// <remarks>
+        /// Blittable native structure for <c>sensor_msgs/srv/SetCameraInfo_Event</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Event info
+            /// Contains event type, timestamp, and request ID
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Service.ServiceEventInfo.Priv Info;
+            
+            /// <summary>
+            /// The actual request content sent or received
+            /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+            /// and the introspection feauture is configured to include payload data.
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/srv/SetCameraInfo_Request[<=1] request]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Sensor.SetCameraInfoServiceRequest.PrivSequence Request;
+            
+            /// <summary>
+            /// The actual response content sent or received
+            /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+            /// and the introspection feauture is configured to include payload data.
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[sensor_msgs/srv/SetCameraInfo_Response[<=1] response]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Sensor.SetCameraInfoServiceResponse.PrivSequence Response;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.Info);
+                __hashCode.Add(this.Request);
+                __hashCode.Add(this.Response);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Sensor.SetCameraInfoServiceEvent.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// This service requests that a camera stores the given CameraInfo as that
+        /// camera's calibration information.
+        /// 
+        /// The width and height in the camera_info field should match what the
+        /// camera is currently outputting on its camera_info topic, and the camera
+        /// will assume that the region of the imager that is being referred to is
+        /// the region that the camera is currently capturing.
+        /// </summary>
+        /// <remarks>
+        /// Blittable native sequence structure for <c>sensor_msgs/srv/SetCameraInfo_Event</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__srv__SetCameraInfo_Event__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Sensor.SetCameraInfoServiceEvent.PrivSequence.{caller}'.");
                 }
             }
         }

--- a/src/Rcl.NET.Tests/Interfaces/Service/Messages/ServiceEventInfo.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Service/Messages/ServiceEventInfo.cs
@@ -11,24 +11,17 @@ using System;
 
 #nullable enable
 
-namespace Rosidl.Messages.Sensor
+namespace Rosidl.Messages.Service
 {
     /// <summary>
-    /// Single pressure reading.  This message is appropriate for measuring the
-    /// pressure inside of a fluid (air, water, etc).  This also includes
-    /// atmospheric or barometric pressure.
-    /// 
-    /// This message is not appropriate for force/pressure contact sensors.
+    /// Message interface definition for <c>service_msgs/msg/ServiceEventInfo</c>.
     /// </summary>
-    /// <remarks>
-    /// Message interface definition for <c>sensor_msgs/msg/FluidPressure</c>.
-    /// </remarks>
-    [global::Rosidl.Runtime.TypeSupportAttribute("sensor_msgs/msg/FluidPressure")]
-    internal unsafe partial class FluidPressure : global::Rosidl.Runtime.IMessage
+    [global::Rosidl.Runtime.TypeSupportAttribute("service_msgs/msg/ServiceEventInfo")]
+    internal unsafe partial class ServiceEventInfo : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
-        public static string TypeSupportName => "sensor_msgs/msg/FluidPressure";
+        public static string TypeSupportName => "service_msgs/msg/ServiceEventInfo";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
@@ -37,83 +30,152 @@ namespace Rosidl.Messages.Sensor
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
             
             [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-            [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__sensor_msgs__msg__FluidPressure")]
+            [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__service_msgs__msg__ServiceEventInfo")]
             static extern nint _PInvoke();
         }
         
         /// <summary>
-        /// Create a new instance of <see cref="FluidPressure"/> with fields initialized to specified values.
+        /// Create a new instance of <see cref="ServiceEventInfo"/> with fields initialized to specified values.
         /// </summary>
-        /// <param name='header'>
-        /// timestamp of the measurement
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>)</para>
+        /// <param name='eventType'>
+        /// The type of event this message represents
+        /// <para>(originally defined as: <c><![CDATA[uint8 event_type]]></c>)</para>
         /// </param>
-        /// <param name='fluidPressure'>
-        /// Absolute pressure reading in Pascals.
-        /// <para>(originally defined as: <c><![CDATA[float64 fluid_pressure]]></c>)</para>
+        /// <param name='stamp'>
+        /// Timestamp for when the event occurred (sent or received time)
+        /// <para>(originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>)</para>
         /// </param>
-        /// <param name='variance'>
-        /// 0 is interpreted as variance unknown
-        /// <para>(originally defined as: <c><![CDATA[float64 variance]]></c>)</para>
+        /// <param name='clientGid'>
+        /// Unique identifier for the client that sent the service request
+        /// Note, this is only unique for the current session.
+        /// The size here has to match the size of rmw_dds_common/msg/Gid,
+        /// but unfortunately we cannot use that message directly due to a
+        /// circular dependency.
+        /// <para>(originally defined as: <c><![CDATA[int8[16] client_gid]]></c>)</para>
+        /// </param>
+        /// <param name='sequenceNumber'>
+        /// Sequence number for the request
+        /// Combined with the client ID, this creates a unique ID for the service transaction
+        /// <para>(originally defined as: <c><![CDATA[int64 sequence_number]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
-        public FluidPressure(
-            global::Rosidl.Messages.Std.Header? @header = null,
-            double @fluidPressure = 0d,
-            double @variance = 0d
+        public ServiceEventInfo(
+            byte @eventType = 0,
+            global::Rosidl.Messages.Builtin.Time? @stamp = null,
+            sbyte[]? @clientGid = null,
+            long @sequenceNumber = 0
         )
         {
-            Header = @header ?? new global::Rosidl.Messages.Std.Header();
-            FluidPressure_ = @fluidPressure;
-            Variance = @variance;
+            EventType = @eventType;
+            Stamp = @stamp ?? new global::Rosidl.Messages.Builtin.Time();
+        
+            if (@clientGid != null)
+            {
+                ClientGid = @clientGid;
+            }
+            else
+            {
+                ClientGid = new sbyte[16];
+            }
+        
+            SequenceNumber = @sequenceNumber;
         }
         
         
         /// <summary>
-        /// Create a new instance of <see cref="FluidPressure"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// Create a new instance of <see cref="ServiceEventInfo"/>, and copy its data from the specified <see cref="Priv"/> structure.
         /// </summary>
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
-        public FluidPressure(in Priv priv, global::System.Text.Encoding textEncoding)
+        public ServiceEventInfo(in Priv priv, global::System.Text.Encoding textEncoding)
         {
-            this.Header = new global::Rosidl.Messages.Std.Header(in priv.Header, textEncoding);
-            this.FluidPressure_ = priv.FluidPressure_;
-            this.Variance = priv.Variance;
+            this.EventType = priv.EventType;
+            this.Stamp = new global::Rosidl.Messages.Builtin.Time(in priv.Stamp, textEncoding);
+            this.ClientGid = priv.ClientGid.ToArray();
+            this.SequenceNumber = priv.SequenceNumber;
         }
         
         
         /// <summary>
-        /// timestamp of the measurement
+        /// Originally defined as: <c><![CDATA[uint8 REQUEST_SENT = 0]]></c>
         /// </summary>
-        /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
-        /// </remarks>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
-        public global::Rosidl.Messages.Std.Header Header { get; set; }
+        public const byte REQUEST_SENT = 0;
         
         /// <summary>
-        /// Absolute pressure reading in Pascals.
+        /// Originally defined as: <c><![CDATA[uint8 REQUEST_RECEIVED = 1]]></c>
         /// </summary>
-        /// <remarks>
-        /// Originally defined as: <c><![CDATA[float64 fluid_pressure]]></c>
-        /// </remarks>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
-        public double FluidPressure_ { get; set; }
+        public const byte REQUEST_RECEIVED = 1;
         
         /// <summary>
-        /// 0 is interpreted as variance unknown
+        /// Originally defined as: <c><![CDATA[uint8 RESPONSE_SENT = 2]]></c>
+        /// </summary>
+        public const byte RESPONSE_SENT = 2;
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[uint8 RESPONSE_RECEIVED = 3]]></c>
+        /// </summary>
+        public const byte RESPONSE_RECEIVED = 3;
+        
+        /// <summary>
+        /// The type of event this message represents
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[float64 variance]]></c>
+        /// Originally defined as: <c><![CDATA[uint8 event_type]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
-        public double Variance { get; set; }
+        public byte EventType { get; set; }
+        
+        /// <summary>
+        /// Timestamp for when the event occurred (sent or received time)
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Builtin.Time Stamp { get; set; }
+        
+        private sbyte[] __backingField__ClientGid;
+        
+        /// <summary>
+        /// Unique identifier for the client that sent the service request
+        /// Note, this is only unique for the current session.
+        /// The size here has to match the size of rmw_dds_common/msg/Gid,
+        /// but unfortunately we cannot use that message directly due to a
+        /// circular dependency.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[int8[16] client_gid]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public sbyte[] ClientGid
+        {
+            get
+            {
+                return __backingField__ClientGid;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__ClientGid))]
+            set
+            {
+                __backingField__ClientGid = value.Length == 16 ? value : throw new global::System.ArgumentException("Size of the array 'ClientGid' must be 16.");
+            }
+        }
+        
+        /// <summary>
+        /// Sequence number for the request
+        /// Combined with the client ID, this creates a unique ID for the service transaction
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[int64 sequence_number]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public long SequenceNumber { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
@@ -126,16 +188,17 @@ namespace Rosidl.Messages.Sensor
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
-            this.Header.WriteTo(ref priv.Header, textEncoding);
-            priv.FluidPressure_ = this.FluidPressure_;
-            priv.Variance = this.Variance;
+            priv.EventType = this.EventType;
+            this.Stamp.WriteTo(ref priv.Stamp, textEncoding);
+            this.ClientGid.CopyTo(priv.ClientGid);
+            priv.SequenceNumber = this.SequenceNumber;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
-            return new FluidPressure(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+            return new ServiceEventInfo(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -181,41 +244,57 @@ namespace Rosidl.Messages.Sensor
         }
         
         /// <summary>
-        /// Single pressure reading.  This message is appropriate for measuring the
-        /// pressure inside of a fluid (air, water, etc).  This also includes
-        /// atmospheric or barometric pressure.
-        /// 
-        /// This message is not appropriate for force/pressure contact sensors.
+        /// Blittable native structure for <c>service_msgs/msg/ServiceEventInfo</c>.
         /// </summary>
-        /// <remarks>
-        /// Blittable native structure for <c>sensor_msgs/msg/FluidPressure</c>.
-        /// </remarks>
         [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// timestamp of the measurement
+            /// The type of event this message represents
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/msg/Header header]]></c>
+            /// Originally defined as: <c><![CDATA[uint8 event_type]]></c>
             /// </remarks>
-            public global::Rosidl.Messages.Std.Header.Priv Header;
+            public byte EventType;
             
             /// <summary>
-            /// Absolute pressure reading in Pascals.
+            /// Timestamp for when the event occurred (sent or received time)
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[float64 fluid_pressure]]></c>
+            /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>
             /// </remarks>
-            public double FluidPressure_;
+            public global::Rosidl.Messages.Builtin.Time.Priv Stamp;
+            
+            private fixed sbyte __ClientGid[16];
             
             /// <summary>
-            /// 0 is interpreted as variance unknown
+            /// Unique identifier for the client that sent the service request
+            /// Note, this is only unique for the current session.
+            /// The size here has to match the size of rmw_dds_common/msg/Gid,
+            /// but unfortunately we cannot use that message directly due to a
+            /// circular dependency.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[float64 variance]]></c>
+            /// Originally defined as: <c><![CDATA[int8[16] client_gid]]></c>
             /// </remarks>
-            public double Variance;
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public global::System.Span<sbyte> ClientGid
+            {
+                get
+                {
+                    fixed (global::Rosidl.Messages.Service.ServiceEventInfo.Priv* __p = &this) return new (__p->__ClientGid, 16);
+                }
+            }
+            
+            /// <summary>
+            /// Sequence number for the request
+            /// Combined with the client ID, this creates a unique ID for the service transaction
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[int64 sequence_number]]></c>
+            /// </remarks>
+            public long SequenceNumber;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
@@ -304,9 +383,14 @@ namespace Rosidl.Messages.Sensor
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
-                __hashCode.Add(this.Header);
-                __hashCode.Add(this.FluidPressure_);
-                __hashCode.Add(this.Variance);
+                __hashCode.Add(this.EventType);
+                __hashCode.Add(this.Stamp);
+                for (int __i = 0; __i < 16; __i++)
+                {
+                    __hashCode.Add(this.ClientGid[__i]);
+                }
+                __hashCode.Add(this.SequenceNumber);
+            
                 return __hashCode.ToHashCode();
             }
             
@@ -331,7 +415,7 @@ namespace Rosidl.Messages.Sensor
                 return _PInvoke();
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__create")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__create")]
                 static extern Priv* _PInvoke();
             }
             
@@ -342,7 +426,7 @@ namespace Rosidl.Messages.Sensor
                 _PInvoke(msg);
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__destroy")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__destroy")]
                 static extern void _PInvoke(Priv* msg);
             }
             
@@ -356,7 +440,7 @@ namespace Rosidl.Messages.Sensor
                 }
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__init")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__init")]
                 static extern bool _PInvoke(Priv* msg);
             }
             
@@ -370,7 +454,7 @@ namespace Rosidl.Messages.Sensor
                 }
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__fini")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__fini")]
                 static extern void _PInvoke(Priv* msg);
             }
             
@@ -384,7 +468,7 @@ namespace Rosidl.Messages.Sensor
                 }
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__are_qual")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__are_qual")]
                 static extern bool _PInvoke(Priv* lhs, Priv* rhs);
             }
             
@@ -395,7 +479,7 @@ namespace Rosidl.Messages.Sensor
                 return _PInvoke(input, output);
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__copy")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__copy")]
                 static extern bool _PInvoke(Priv* input, Priv* output);
             }
             
@@ -406,21 +490,14 @@ namespace Rosidl.Messages.Sensor
             {
                 if (!ret)
                 {
-                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Sensor.FluidPressure.Priv.{caller}'.");
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Service.ServiceEventInfo.Priv.{caller}'.");
                 }
             }
         }
         
         /// <summary>
-        /// Single pressure reading.  This message is appropriate for measuring the
-        /// pressure inside of a fluid (air, water, etc).  This also includes
-        /// atmospheric or barometric pressure.
-        /// 
-        /// This message is not appropriate for force/pressure contact sensors.
+        /// Blittable native sequence structure for <c>service_msgs/msg/ServiceEventInfo</c>.
         /// </summary>
-        /// <remarks>
-        /// Blittable native sequence structure for <c>sensor_msgs/msg/FluidPressure</c>.
-        /// </remarks>
         [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
         {
@@ -575,7 +652,7 @@ namespace Rosidl.Messages.Sensor
                 return _PInvoke();
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__Sequence__create")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__Sequence__create")]
                 static extern PrivSequence* _PInvoke();
             }
             
@@ -586,7 +663,7 @@ namespace Rosidl.Messages.Sensor
                 _PInvoke(msg);
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__Sequence__destroy")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__Sequence__destroy")]
                 static extern void _PInvoke(PrivSequence* msg);
             }
             
@@ -600,7 +677,7 @@ namespace Rosidl.Messages.Sensor
                 }
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__Sequence__init")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__Sequence__init")]
                 static extern bool _PInvoke(PrivSequence* msg, nuint size);
             }
             
@@ -614,7 +691,7 @@ namespace Rosidl.Messages.Sensor
                 }
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__Sequence__fini")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__Sequence__fini")]
                 static extern void _PInvoke(PrivSequence* msg);
             }
             
@@ -628,7 +705,7 @@ namespace Rosidl.Messages.Sensor
                 }
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__Sequence__are_qual")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__Sequence__are_qual")]
                 static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
             }
             
@@ -639,7 +716,7 @@ namespace Rosidl.Messages.Sensor
                 return _PInvoke(input, output);
                 
                 [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
-                [global::System.Runtime.InteropServices.DllImportAttribute("sensor_msgs__rosidl_generator_c", EntryPoint = "sensor_msgs__msg__FluidPressure__Sequence__copy")]
+                [global::System.Runtime.InteropServices.DllImportAttribute("service_msgs__rosidl_generator_c", EntryPoint = "service_msgs__msg__ServiceEventInfo__Sequence__copy")]
                 static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
             }
             
@@ -650,7 +727,7 @@ namespace Rosidl.Messages.Sensor
             {
                 if (!ret)
                 {
-                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Sensor.FluidPressure.PrivSequence.{caller}'.");
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Service.ServiceEventInfo.PrivSequence.{caller}'.");
                 }
             }
         }

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Bool.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Bool.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Bool : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Bool";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[bool data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Bool(
             bool @data = false
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Bool(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[bool data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public bool Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Bool(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public bool Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Byte.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Byte.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Byte : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Byte";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint8 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Byte(
             byte @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Byte(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint8 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Byte(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public byte Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/ByteMultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/ByteMultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class ByteMultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/ByteMultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[uint8[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ByteMultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             byte[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ByteMultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint8[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new ByteMultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.UInt8Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Char.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Char.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Char : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Char";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int8 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Char(
             sbyte @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Char(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int8 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public sbyte Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Char(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public sbyte Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/ColorRGBA.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/ColorRGBA.cs
@@ -20,11 +20,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class ColorRGBA : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/ColorRGBA";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -50,7 +50,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[float32 a]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ColorRGBA(
             float @r = 0f,
             float @g = 0f,
@@ -71,7 +71,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ColorRGBA(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.R = priv.R;
@@ -85,39 +85,39 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[float32 r]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float R { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float32 g]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float G { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float32 b]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float B { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[float32 a]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float A { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.R = this.R;
@@ -127,49 +127,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new ColorRGBA(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -202,21 +202,21 @@ namespace Rosidl.Messages.Std
             public float A;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -224,7 +224,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -232,28 +232,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -263,7 +263,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -273,18 +273,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -296,21 +296,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -321,7 +321,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -374,7 +374,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -385,7 +385,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -413,28 +413,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -450,7 +450,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -458,21 +458,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -481,21 +481,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -505,7 +505,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -515,39 +515,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -558,7 +558,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -583,7 +583,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -597,7 +597,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -611,7 +611,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -622,7 +622,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Empty.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Empty.cs
@@ -20,11 +20,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Empty : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Empty";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -38,7 +38,7 @@ namespace Rosidl.Messages.Std
         /// Create a new instance of <see cref="Empty"/> with fields initialized to specified values.
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Empty() { }
         
         
@@ -48,69 +48,69 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Empty(in Priv priv, global::System.Text.Encoding textEncoding)
         {
         }
         
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Empty(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -123,21 +123,21 @@ namespace Rosidl.Messages.Std
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -145,7 +145,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -153,28 +153,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -184,7 +184,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -194,18 +194,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -214,21 +214,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -239,7 +239,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -250,7 +250,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -264,7 +264,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -278,7 +278,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -292,7 +292,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -303,7 +303,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -331,28 +331,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -368,7 +368,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -376,21 +376,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -399,21 +399,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -423,7 +423,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -433,39 +433,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -476,7 +476,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -487,7 +487,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -501,7 +501,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -515,7 +515,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -529,7 +529,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -540,7 +540,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Float32.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Float32.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Float32 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Float32";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[float32 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Float32(
             float @data = 0f
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Float32(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[float32 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Float32(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public float Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Float32MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Float32MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Float32MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Float32MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[float32[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Float32MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             float[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Float32MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[float32[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public float[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Float32MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.FloatSequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Float64.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Float64.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Float64 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Float64";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[float64 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Float64(
             double @data = 0d
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Float64(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[float64 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Float64(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public double Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Float64MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Float64MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Float64MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Float64MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[float64[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Float64MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             double[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Float64MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[float64[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public double[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Float64MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.DoubleSequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Header.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Header.cs
@@ -25,11 +25,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Header : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Header";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -44,14 +44,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='stamp'>
         /// Two-integer timestamp that is expressed as seconds and nanoseconds.
-        /// <para>(originally defined as: <c><![CDATA[builtin_interfaces/Time stamp]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>)</para>
         /// </param>
         /// <param name='frameId'>
         /// Transform frame with which this data is associated.
         /// <para>(originally defined as: <c><![CDATA[string frame_id]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Header(
             global::Rosidl.Messages.Builtin.Time? @stamp = null,
             string @frameId = ""
@@ -68,7 +68,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Header(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Stamp = new global::Rosidl.Messages.Builtin.Time(in priv.Stamp, textEncoding);
@@ -80,10 +80,10 @@ namespace Rosidl.Messages.Std
         /// Two-integer timestamp that is expressed as seconds and nanoseconds.
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[builtin_interfaces/Time stamp]]></c>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Builtin.Time Stamp { get; set; }
         
         /// <summary>
@@ -93,18 +93,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[string frame_id]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string FrameId { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Stamp.WriteTo(ref priv.Stamp, textEncoding);
@@ -112,49 +112,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Header(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -175,7 +175,7 @@ namespace Rosidl.Messages.Std
             /// Two-integer timestamp that is expressed as seconds and nanoseconds.
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[builtin_interfaces/Time stamp]]></c>
+            /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Builtin.Time.Priv Stamp;
             
@@ -188,21 +188,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.CString FrameId;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -210,7 +210,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -218,28 +218,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -249,7 +249,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -259,18 +259,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -280,21 +280,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -305,7 +305,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -316,7 +316,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -330,7 +330,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -344,7 +344,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -358,7 +358,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -369,7 +369,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -402,28 +402,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -431,7 +431,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -439,7 +439,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -447,21 +447,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -470,21 +470,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -494,7 +494,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -504,39 +504,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -547,7 +547,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -558,7 +558,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -572,7 +572,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -586,7 +586,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -600,7 +600,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -611,7 +611,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int16.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int16.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Int16 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Int16";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int16 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int16(
             short @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int16(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int16 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public short Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Int16(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public short Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int16MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int16MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Int16MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Int16MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[int16[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int16MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             short[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int16MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int16[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public short[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Int16MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.Int16Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int32.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int32.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Int32 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Int32";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int32 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int32(
             int @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int32(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int32 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public int Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Int32(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public int Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int32MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int32MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Int32MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Int32MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[int32[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int32MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             int[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int32MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int32[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public int[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Int32MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.Int32Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int64.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int64.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Int64 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Int64";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int64 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int64(
             long @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int64(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int64 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public long Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Int64(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public long Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int64MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int64MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Int64MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Int64MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[int64[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int64MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             long[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int64MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int64[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public long[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Int64MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.Int64Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int8.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int8.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Int8 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Int8";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int8 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int8(
             sbyte @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int8(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int8 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public sbyte Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Int8(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public sbyte Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int8MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/Int8MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class Int8MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/Int8MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[int8[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int8MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             sbyte[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public Int8MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[int8[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public sbyte[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new Int8MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.Int8Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/MultiArrayDimension.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/MultiArrayDimension.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class MultiArrayDimension : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/MultiArrayDimension";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -56,7 +56,7 @@ namespace Rosidl.Messages.Std
         /// <para>(originally defined as: <c><![CDATA[uint32 stride]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MultiArrayDimension(
             string @label = "",
             uint @size = 0,
@@ -75,7 +75,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MultiArrayDimension(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Label = global::Rosidl.Runtime.Interop.StringMarshal.CreatePooledString(priv.Label.AsSpan(), textEncoding);
@@ -91,7 +91,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[string label]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string Label { get; set; }
         
         /// <summary>
@@ -101,7 +101,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint32 size]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Size { get; set; }
         
         /// <summary>
@@ -111,18 +111,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint32 stride]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Stride { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Label.CopyFrom(this.Label, textEncoding);
@@ -131,49 +131,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new MultiArrayDimension(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -216,21 +216,21 @@ namespace Rosidl.Messages.Std
             public uint Stride;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -238,7 +238,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -246,28 +246,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -277,7 +277,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -287,18 +287,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -309,21 +309,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -334,7 +334,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -345,7 +345,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -359,7 +359,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -373,7 +373,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -387,7 +387,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -398,7 +398,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -432,28 +432,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -461,7 +461,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -469,7 +469,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -477,21 +477,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -500,21 +500,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -524,7 +524,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -534,39 +534,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -577,7 +577,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -588,7 +588,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -602,7 +602,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -616,7 +616,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -630,7 +630,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -641,7 +641,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/MultiArrayLayout.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/MultiArrayLayout.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class MultiArrayLayout : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/MultiArrayLayout";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='dim'>
         /// Array of dimension properties
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayDimension[] dim]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayDimension[] dim]]></c>)</para>
         /// </param>
         /// <param name='dataOffset'>
         /// padding bytes at front of data
         /// <para>(originally defined as: <c><![CDATA[uint32 data_offset]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MultiArrayLayout(
             global::Rosidl.Messages.Std.MultiArrayDimension[]? @dim = null,
             uint @dataOffset = 0
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public MultiArrayLayout(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Dim = new global::Rosidl.Messages.Std.MultiArrayDimension[priv.Dim.Size];
@@ -87,10 +87,10 @@ namespace Rosidl.Messages.Std
         /// Array of dimension properties
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayDimension[] dim]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayDimension[] dim]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayDimension[] Dim { get; set; }
         
         /// <summary>
@@ -100,18 +100,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint32 data_offset]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint DataOffset { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Dim = new global::Rosidl.Messages.Std.MultiArrayDimension.PrivSequence(this.Dim.Length);
@@ -125,49 +125,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new MultiArrayLayout(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -189,7 +189,7 @@ namespace Rosidl.Messages.Std
             /// Array of dimension properties
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayDimension[] dim]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayDimension[] dim]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayDimension.PrivSequence Dim;
             
@@ -202,21 +202,21 @@ namespace Rosidl.Messages.Std
             public uint DataOffset;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -224,7 +224,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -232,28 +232,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -263,7 +263,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -273,18 +273,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -294,21 +294,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -319,7 +319,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -330,7 +330,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -344,7 +344,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -358,7 +358,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -372,7 +372,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -383,7 +383,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -417,28 +417,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -446,7 +446,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -454,7 +454,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -462,21 +462,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -485,21 +485,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -509,7 +509,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -519,39 +519,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -562,7 +562,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -573,7 +573,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -587,7 +587,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -601,7 +601,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -615,7 +615,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -626,7 +626,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/String.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/String.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class String : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/String";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[string data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public String(
             string @data = ""
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public String(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = global::Rosidl.Runtime.Interop.StringMarshal.CreatePooledString(priv.Data.AsSpan(), textEncoding);
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[string data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data.CopyFrom(this.Data, textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new String(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.CString Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt16.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt16.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class UInt16 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/UInt16";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint16 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt16(
             ushort @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt16(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint16 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ushort Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new UInt16(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public ushort Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt16MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt16MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class UInt16MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/UInt16MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[uint16[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt16MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             ushort[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt16MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint16[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ushort[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new UInt16MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.UInt16Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt32.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt32.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class UInt32 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/UInt32";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint32 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt32(
             uint @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt32(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint32 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new UInt32(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public uint Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt32MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt32MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class UInt32MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/UInt32MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[uint32[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt32MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             uint[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt32MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint32[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public uint[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new UInt32MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.UInt32Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt64.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt64.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class UInt64 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/UInt64";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint64 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt64(
             ulong @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt64(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint64 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ulong Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new UInt64(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public ulong Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt64MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt64MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class UInt64MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/UInt64MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[uint64[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt64MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             ulong[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt64MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint64[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public ulong[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new UInt64MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.UInt64Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt8.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt8.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class UInt8 : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/UInt8";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -47,7 +47,7 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint8 data]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt8(
             byte @data = 0
         )
@@ -62,7 +62,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt8(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Data = priv.Data;
@@ -73,67 +73,67 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint8 data]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Data = this.Data;
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new UInt8(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -157,21 +157,21 @@ namespace Rosidl.Messages.Std
             public byte Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -179,7 +179,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -187,28 +187,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -218,7 +218,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -228,18 +228,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -248,21 +248,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -273,7 +273,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -284,7 +284,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -298,7 +298,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -312,7 +312,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -326,7 +326,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -337,7 +337,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -371,28 +371,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -408,7 +408,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -416,21 +416,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -439,21 +439,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -463,7 +463,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -473,39 +473,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -516,7 +516,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -527,7 +527,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -541,7 +541,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -555,7 +555,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -569,7 +569,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -580,7 +580,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt8MultiArray.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Std/Messages/UInt8MultiArray.cs
@@ -26,11 +26,11 @@ namespace Rosidl.Messages.Std
     internal unsafe partial class UInt8MultiArray : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "std_msgs/msg/UInt8MultiArray";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -45,14 +45,14 @@ namespace Rosidl.Messages.Std
         /// </summary>
         /// <param name='layout'>
         /// specification of data layout
-        /// <para>(originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>)</para>
         /// </param>
         /// <param name='data'>
         /// array of data
         /// <para>(originally defined as: <c><![CDATA[uint8[] data]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt8MultiArray(
             global::Rosidl.Messages.Std.MultiArrayLayout? @layout = null,
             byte[]? @data = null
@@ -69,7 +69,7 @@ namespace Rosidl.Messages.Std
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public UInt8MultiArray(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout = new global::Rosidl.Messages.Std.MultiArrayLayout(in priv.Layout, textEncoding);
@@ -81,10 +81,10 @@ namespace Rosidl.Messages.Std
         /// specification of data layout
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+        /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Std.MultiArrayLayout Layout { get; set; }
         
         /// <summary>
@@ -94,18 +94,18 @@ namespace Rosidl.Messages.Std
         /// Originally defined as: <c><![CDATA[uint8[] data]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte[] Data { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Layout.WriteTo(ref priv.Layout, textEncoding);
@@ -113,49 +113,49 @@ namespace Rosidl.Messages.Std
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new UInt8MultiArray(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Std
             /// specification of data layout
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[std_msgs/MultiArrayLayout layout]]></c>
+            /// Originally defined as: <c><![CDATA[std_msgs/msg/MultiArrayLayout layout]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Std.MultiArrayLayout.Priv Layout;
             
@@ -190,21 +190,21 @@ namespace Rosidl.Messages.Std
             public global::Rosidl.Runtime.Interop.UInt8Sequence Data;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -212,7 +212,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -220,28 +220,28 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -251,7 +251,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -261,18 +261,18 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -282,21 +282,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -307,7 +307,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -318,7 +318,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -332,7 +332,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -346,7 +346,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -360,7 +360,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -371,7 +371,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -405,28 +405,28 @@ namespace Rosidl.Messages.Std
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -434,7 +434,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -442,7 +442,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -450,21 +450,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -473,21 +473,21 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -507,39 +507,39 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -550,7 +550,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -575,7 +575,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -589,7 +589,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -603,7 +603,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -614,7 +614,7 @@ namespace Rosidl.Messages.Std
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Tf2/Actions/LookupTransform.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Tf2/Actions/LookupTransform.cs
@@ -23,11 +23,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class LookupTransformAction : global::Rosidl.Runtime.IAction<LookupTransformActionGoal, LookupTransformActionResult, LookupTransformActionFeedback>
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/action/LookupTransform";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Action);
@@ -48,11 +48,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class LookupTransformActionGoal : global::Rosidl.Runtime.IActionGoal
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/action/LookupTransform_Goal";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -73,14 +73,14 @@ namespace Rosidl.Messages.Tf2
         /// Originally defined as: <c><![CDATA[string source_frame]]></c>
         /// </param>
         /// <param name='sourceTime'>
-        /// Originally defined as: <c><![CDATA[builtin_interfaces/Time source_time]]></c>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time source_time]]></c>
         /// </param>
         /// <param name='timeout'>
-        /// Originally defined as: <c><![CDATA[builtin_interfaces/Duration timeout]]></c>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Duration timeout]]></c>
         /// </param>
         /// <param name='targetTime'>
         /// Advanced API
-        /// <para>(originally defined as: <c><![CDATA[builtin_interfaces/Time target_time]]></c>)</para>
+        /// <para>(originally defined as: <c><![CDATA[builtin_interfaces/msg/Time target_time]]></c>)</para>
         /// </param>
         /// <param name='fixedFrame'>
         /// Originally defined as: <c><![CDATA[string fixed_frame]]></c>
@@ -90,7 +90,7 @@ namespace Rosidl.Messages.Tf2
         /// <para>(originally defined as: <c><![CDATA[bool advanced]]></c>)</para>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LookupTransformActionGoal(
             string @targetFrame = "",
             string @sourceFrame = "",
@@ -117,7 +117,7 @@ namespace Rosidl.Messages.Tf2
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LookupTransformActionGoal(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.TargetFrame = global::Rosidl.Runtime.Interop.StringMarshal.CreatePooledString(priv.TargetFrame.AsSpan(), textEncoding);
@@ -137,45 +137,45 @@ namespace Rosidl.Messages.Tf2
         /// Originally defined as: <c><![CDATA[string target_frame]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string TargetFrame { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[string source_frame]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string SourceFrame { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[builtin_interfaces/Time source_time]]></c>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time source_time]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Builtin.Time SourceTime { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[builtin_interfaces/Duration timeout]]></c>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Duration timeout]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Builtin.Duration Timeout { get; set; }
         
         /// <summary>
         /// Advanced API
         /// </summary>
         /// <remarks>
-        /// Originally defined as: <c><![CDATA[builtin_interfaces/Time target_time]]></c>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time target_time]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Builtin.Time TargetTime { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[string fixed_frame]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string FixedFrame { get; set; }
         
         /// <summary>
@@ -185,18 +185,18 @@ namespace Rosidl.Messages.Tf2
         /// Originally defined as: <c><![CDATA[bool advanced]]></c>
         /// </remarks>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public bool Advanced { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.TargetFrame.CopyFrom(this.TargetFrame, textEncoding);
@@ -209,49 +209,49 @@ namespace Rosidl.Messages.Tf2
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new LookupTransformActionGoal(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -280,12 +280,12 @@ namespace Rosidl.Messages.Tf2
             public global::Rosidl.Runtime.Interop.CString SourceFrame;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[builtin_interfaces/Time source_time]]></c>
+            /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time source_time]]></c>
             /// </summary>
             public global::Rosidl.Messages.Builtin.Time.Priv SourceTime;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[builtin_interfaces/Duration timeout]]></c>
+            /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Duration timeout]]></c>
             /// </summary>
             public global::Rosidl.Messages.Builtin.Duration.Priv Timeout;
             
@@ -293,7 +293,7 @@ namespace Rosidl.Messages.Tf2
             /// Advanced API
             /// </summary>
             /// <remarks>
-            /// Originally defined as: <c><![CDATA[builtin_interfaces/Time target_time]]></c>
+            /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time target_time]]></c>
             /// </remarks>
             public global::Rosidl.Messages.Builtin.Time.Priv TargetTime;
             
@@ -311,21 +311,21 @@ namespace Rosidl.Messages.Tf2
             public bool Advanced;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -333,7 +333,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -341,28 +341,28 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -372,7 +372,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -382,18 +382,18 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -408,21 +408,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -433,7 +433,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -444,7 +444,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -458,7 +458,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -472,7 +472,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -486,7 +486,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -497,7 +497,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -528,28 +528,28 @@ namespace Rosidl.Messages.Tf2
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -557,7 +557,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -565,7 +565,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -573,21 +573,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -596,21 +596,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -620,7 +620,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -630,39 +630,39 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -673,7 +673,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -684,7 +684,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -698,7 +698,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -712,7 +712,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -726,7 +726,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -737,7 +737,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -759,11 +759,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class LookupTransformActionResult : global::Rosidl.Runtime.IActionResult
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/action/LookupTransform_Result";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -777,13 +777,13 @@ namespace Rosidl.Messages.Tf2
         /// Create a new instance of <see cref="LookupTransformActionResult"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='transform'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/TransformStamped transform]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TransformStamped transform]]></c>
         /// </param>
         /// <param name='error'>
-        /// Originally defined as: <c><![CDATA[tf2_msgs/TF2Error error]]></c>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/msg/TF2Error error]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LookupTransformActionResult(
             global::Rosidl.Messages.Geometry.TransformStamped? @transform = null,
             global::Rosidl.Messages.Tf2.TF2Error? @error = null
@@ -800,7 +800,7 @@ namespace Rosidl.Messages.Tf2
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LookupTransformActionResult(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Transform = new global::Rosidl.Messages.Geometry.TransformStamped(in priv.Transform, textEncoding);
@@ -809,28 +809,28 @@ namespace Rosidl.Messages.Tf2
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/TransformStamped transform]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TransformStamped transform]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.TransformStamped Transform { get; set; }
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[tf2_msgs/TF2Error error]]></c>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/msg/TF2Error error]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Tf2.TF2Error Error { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Transform.WriteTo(ref priv.Transform, textEncoding);
@@ -838,49 +838,49 @@ namespace Rosidl.Messages.Tf2
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new LookupTransformActionResult(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -896,31 +896,31 @@ namespace Rosidl.Messages.Tf2
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/TransformStamped transform]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TransformStamped transform]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.TransformStamped.Priv Transform;
             
             /// <summary>
-            /// Originally defined as: <c><![CDATA[tf2_msgs/TF2Error error]]></c>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/msg/TF2Error error]]></c>
             /// </summary>
             public global::Rosidl.Messages.Tf2.TF2Error.Priv Error;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -928,7 +928,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -936,28 +936,28 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -967,7 +967,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -977,18 +977,18 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -998,21 +998,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -1023,7 +1023,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -1034,7 +1034,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -1048,7 +1048,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -1062,7 +1062,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -1076,7 +1076,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -1087,7 +1087,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -1118,28 +1118,28 @@ namespace Rosidl.Messages.Tf2
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -1147,7 +1147,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -1155,7 +1155,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -1163,21 +1163,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -1186,21 +1186,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -1210,7 +1210,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -1220,39 +1220,39 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -1263,7 +1263,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -1274,7 +1274,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1288,7 +1288,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1302,7 +1302,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -1316,7 +1316,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -1327,7 +1327,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -1349,11 +1349,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class LookupTransformActionFeedback : global::Rosidl.Runtime.IActionFeedback
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/action/LookupTransform_Feedback";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -1367,7 +1367,7 @@ namespace Rosidl.Messages.Tf2
         /// Create a new instance of <see cref="LookupTransformActionFeedback"/> with fields initialized to specified values.
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LookupTransformActionFeedback() { }
         
         
@@ -1377,69 +1377,69 @@ namespace Rosidl.Messages.Tf2
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public LookupTransformActionFeedback(in Priv priv, global::System.Text.Encoding textEncoding)
         {
         }
         
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new LookupTransformActionFeedback(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -1455,21 +1455,21 @@ namespace Rosidl.Messages.Tf2
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -1477,7 +1477,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -1485,28 +1485,28 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -1516,7 +1516,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -1526,18 +1526,18 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -1546,21 +1546,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -1571,7 +1571,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -1582,7 +1582,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -1596,7 +1596,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -1610,7 +1610,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -1624,7 +1624,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -1635,7 +1635,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -1666,28 +1666,28 @@ namespace Rosidl.Messages.Tf2
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -1695,7 +1695,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -1703,7 +1703,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -1711,21 +1711,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -1734,21 +1734,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -1758,7 +1758,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -1768,39 +1768,39 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -1811,7 +1811,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -1822,7 +1822,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1836,7 +1836,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1850,7 +1850,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -1864,7 +1864,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -1875,13 +1875,4385 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
                 if (!ret)
                 {
                     throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionFeedback.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Message interface definition for <c>tf2_msgs/action/LookupTransform_FeedbackMessage</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_FeedbackMessage")]
+    internal unsafe partial class LookupTransformActionFeedbackMessage : global::Rosidl.Runtime.IMessage
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_FeedbackMessage";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__tf2_msgs__action__LookupTransform_FeedbackMessage")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionFeedbackMessage"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='goalId'>
+        /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+        /// </param>
+        /// <param name='feedback'>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Feedback feedback]]></c>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionFeedbackMessage(
+            global::Rosidl.Messages.UniqueIdentifier.UUID? @goalId = null,
+            global::Rosidl.Messages.Tf2.LookupTransformActionFeedback? @feedback = null
+        )
+        {
+            GoalId = @goalId ?? new global::Rosidl.Messages.UniqueIdentifier.UUID();
+            Feedback = @feedback ?? new global::Rosidl.Messages.Tf2.LookupTransformActionFeedback();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionFeedbackMessage"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionFeedbackMessage(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.GoalId = new global::Rosidl.Messages.UniqueIdentifier.UUID(in priv.GoalId, textEncoding);
+            this.Feedback = new global::Rosidl.Messages.Tf2.LookupTransformActionFeedback(in priv.Feedback, textEncoding);
+        }
+        
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.UniqueIdentifier.UUID GoalId { get; set; }
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Feedback feedback]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.LookupTransformActionFeedback Feedback { get; set; }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.GoalId.WriteTo(ref priv.GoalId, textEncoding);
+            this.Feedback.WriteTo(ref priv.Feedback, textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new LookupTransformActionFeedbackMessage(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native structure for <c>tf2_msgs/action/LookupTransform_FeedbackMessage</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+            /// </summary>
+            public global::Rosidl.Messages.UniqueIdentifier.UUID.Priv GoalId;
+            
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Feedback feedback]]></c>
+            /// </summary>
+            public global::Rosidl.Messages.Tf2.LookupTransformActionFeedback.Priv Feedback;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.GoalId);
+                __hashCode.Add(this.Feedback);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionFeedbackMessage.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native sequence structure for <c>tf2_msgs/action/LookupTransform_FeedbackMessage</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_FeedbackMessage__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionFeedbackMessage.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Service interface definition for <c>tf2_msgs/action/LookupTransform_SendGoal</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_SendGoal")]
+    internal unsafe partial class LookupTransformActionSendGoalService : global::Rosidl.Runtime.IService<LookupTransformActionSendGoalServiceRequest, LookupTransformActionSendGoalServiceResponse>
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_SendGoal";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Service);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_service_type_support_handle__tf2_msgs__action__LookupTransform_SendGoal")]
+            static extern nint _PInvoke();
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Message interface definition for <c>tf2_msgs/action/LookupTransform_SendGoal_Request</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_SendGoal_Request")]
+    internal unsafe partial class LookupTransformActionSendGoalServiceRequest : global::Rosidl.Runtime.IServiceRequest
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_SendGoal_Request";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__tf2_msgs__action__LookupTransform_SendGoal_Request")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionSendGoalServiceRequest"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='goalId'>
+        /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+        /// </param>
+        /// <param name='goal'>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Goal goal]]></c>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionSendGoalServiceRequest(
+            global::Rosidl.Messages.UniqueIdentifier.UUID? @goalId = null,
+            global::Rosidl.Messages.Tf2.LookupTransformActionGoal? @goal = null
+        )
+        {
+            GoalId = @goalId ?? new global::Rosidl.Messages.UniqueIdentifier.UUID();
+            Goal = @goal ?? new global::Rosidl.Messages.Tf2.LookupTransformActionGoal();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionSendGoalServiceRequest"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionSendGoalServiceRequest(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.GoalId = new global::Rosidl.Messages.UniqueIdentifier.UUID(in priv.GoalId, textEncoding);
+            this.Goal = new global::Rosidl.Messages.Tf2.LookupTransformActionGoal(in priv.Goal, textEncoding);
+        }
+        
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.UniqueIdentifier.UUID GoalId { get; set; }
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Goal goal]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.LookupTransformActionGoal Goal { get; set; }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.GoalId.WriteTo(ref priv.GoalId, textEncoding);
+            this.Goal.WriteTo(ref priv.Goal, textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new LookupTransformActionSendGoalServiceRequest(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native structure for <c>tf2_msgs/action/LookupTransform_SendGoal_Request</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+            /// </summary>
+            public global::Rosidl.Messages.UniqueIdentifier.UUID.Priv GoalId;
+            
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Goal goal]]></c>
+            /// </summary>
+            public global::Rosidl.Messages.Tf2.LookupTransformActionGoal.Priv Goal;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.GoalId);
+                __hashCode.Add(this.Goal);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native sequence structure for <c>tf2_msgs/action/LookupTransform_SendGoal_Request</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Request__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Message interface definition for <c>tf2_msgs/action/LookupTransform_SendGoal_Response</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_SendGoal_Response")]
+    internal unsafe partial class LookupTransformActionSendGoalServiceResponse : global::Rosidl.Runtime.IServiceResponse
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_SendGoal_Response";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__tf2_msgs__action__LookupTransform_SendGoal_Response")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionSendGoalServiceResponse"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='accepted'>
+        /// Originally defined as: <c><![CDATA[bool accepted]]></c>
+        /// </param>
+        /// <param name='stamp'>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionSendGoalServiceResponse(
+            bool @accepted = false,
+            global::Rosidl.Messages.Builtin.Time? @stamp = null
+        )
+        {
+            Accepted = @accepted;
+            Stamp = @stamp ?? new global::Rosidl.Messages.Builtin.Time();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionSendGoalServiceResponse"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionSendGoalServiceResponse(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Accepted = priv.Accepted;
+            this.Stamp = new global::Rosidl.Messages.Builtin.Time(in priv.Stamp, textEncoding);
+        }
+        
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[bool accepted]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public bool Accepted { get; set; }
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Builtin.Time Stamp { get; set; }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            priv.Accepted = this.Accepted;
+            this.Stamp.WriteTo(ref priv.Stamp, textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new LookupTransformActionSendGoalServiceResponse(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native structure for <c>tf2_msgs/action/LookupTransform_SendGoal_Response</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[bool accepted]]></c>
+            /// </summary>
+            public bool Accepted;
+            
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[builtin_interfaces/msg/Time stamp]]></c>
+            /// </summary>
+            public global::Rosidl.Messages.Builtin.Time.Priv Stamp;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.Accepted);
+                __hashCode.Add(this.Stamp);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native sequence structure for <c>tf2_msgs/action/LookupTransform_SendGoal_Response</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Response__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Message interface definition for <c>tf2_msgs/action/LookupTransform_SendGoal_Event</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_SendGoal_Event")]
+    internal unsafe partial class LookupTransformActionSendGoalServiceEvent : global::Rosidl.Runtime.IServiceEvent
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_SendGoal_Event";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__tf2_msgs__action__LookupTransform_SendGoal_Event")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionSendGoalServiceEvent"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='info'>
+        /// Event info
+        /// Contains event type, timestamp, and request ID
+        /// <para>(originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>)</para>
+        /// </param>
+        /// <param name='request'>
+        /// The actual request content sent or received
+        /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// <para>(originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_SendGoal_Request[<=1] request]]></c>)</para>
+        /// </param>
+        /// <param name='response'>
+        /// The actual response content sent or received
+        /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// <para>(originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_SendGoal_Response[<=1] response]]></c>)</para>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionSendGoalServiceEvent(
+            global::Rosidl.Messages.Service.ServiceEventInfo? @info = null,
+            global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest[]? @request = null,
+            global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse[]? @response = null
+        )
+        {
+            Info = @info ?? new global::Rosidl.Messages.Service.ServiceEventInfo();
+            Request = @request ?? global::System.Array.Empty<global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest>();
+            Response = @response ?? global::System.Array.Empty<global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse>();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionSendGoalServiceEvent"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionSendGoalServiceEvent(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Info = new global::Rosidl.Messages.Service.ServiceEventInfo(in priv.Info, textEncoding);
+        
+            this.Request = new global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest[priv.Request.Size];
+            var Request_span = priv.Request.AsSpan();
+            for (int __i = 0; __i < this.Request.Length; __i++)
+            {
+                this.Request[__i] = new global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest(in Request_span[__i], textEncoding);
+            }
+        
+            this.Response = new global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse[priv.Response.Size];
+            var Response_span = priv.Response.AsSpan();
+            for (int __i = 0; __i < this.Response.Length; __i++)
+            {
+                this.Response[__i] = new global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse(in Response_span[__i], textEncoding);
+            }
+        }
+        
+        
+        /// <summary>
+        /// Event info
+        /// Contains event type, timestamp, and request ID
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Service.ServiceEventInfo Info { get; set; }
+        
+        private global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest[] __backingField__Request;
+        
+        /// <summary>
+        /// The actual request content sent or received
+        /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_SendGoal_Request[<=1] request]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest[] Request
+        {
+            get
+            {
+                return __backingField__Request;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__Request))]
+            set
+            {
+                __backingField__Request = value.Length <= 1 ? value : throw new global::System.ArgumentException("Size of the array or string 'Request' must be less or equal than 1.");
+            }
+        }
+        
+        private global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse[] __backingField__Response;
+        
+        /// <summary>
+        /// The actual response content sent or received
+        /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_SendGoal_Response[<=1] response]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse[] Response
+        {
+            get
+            {
+                return __backingField__Response;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__Response))]
+            set
+            {
+                __backingField__Response = value.Length <= 1 ? value : throw new global::System.ArgumentException("Size of the array or string 'Response' must be less or equal than 1.");
+            }
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Info.WriteTo(ref priv.Info, textEncoding);
+            
+            priv.Request = new global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest.PrivSequence(this.Request.Length);
+            var Request_span = priv.Request.AsSpan();
+            for (int __i = 0; __i < this.Request.Length; __i++)
+            {
+                this.Request[__i].WriteTo(ref Request_span[__i], textEncoding);
+            }
+            
+            priv.Response = new global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse.PrivSequence(this.Response.Length);
+            var Response_span = priv.Response.AsSpan();
+            for (int __i = 0; __i < this.Response.Length; __i++)
+            {
+                this.Response[__i].WriteTo(ref Response_span[__i], textEncoding);
+            }
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new LookupTransformActionSendGoalServiceEvent(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native structure for <c>tf2_msgs/action/LookupTransform_SendGoal_Event</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Event info
+            /// Contains event type, timestamp, and request ID
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Service.ServiceEventInfo.Priv Info;
+            
+            /// <summary>
+            /// The actual request content sent or received
+            /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+            /// and the introspection feauture is configured to include payload data.
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_SendGoal_Request[<=1] request]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceRequest.PrivSequence Request;
+            
+            /// <summary>
+            /// The actual response content sent or received
+            /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+            /// and the introspection feauture is configured to include payload data.
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_SendGoal_Response[<=1] response]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceResponse.PrivSequence Response;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.Info);
+                __hashCode.Add(this.Request);
+                __hashCode.Add(this.Response);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceEvent.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native sequence structure for <c>tf2_msgs/action/LookupTransform_SendGoal_Event</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_SendGoal_Event__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionSendGoalServiceEvent.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Service interface definition for <c>tf2_msgs/action/LookupTransform_GetResult</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_GetResult")]
+    internal unsafe partial class LookupTransformActionGetResultService : global::Rosidl.Runtime.IService<LookupTransformActionGetResultServiceRequest, LookupTransformActionGetResultServiceResponse>
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_GetResult";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Service);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_service_type_support_handle__tf2_msgs__action__LookupTransform_GetResult")]
+            static extern nint _PInvoke();
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Message interface definition for <c>tf2_msgs/action/LookupTransform_GetResult_Request</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_GetResult_Request")]
+    internal unsafe partial class LookupTransformActionGetResultServiceRequest : global::Rosidl.Runtime.IServiceRequest
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_GetResult_Request";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__tf2_msgs__action__LookupTransform_GetResult_Request")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionGetResultServiceRequest"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='goalId'>
+        /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionGetResultServiceRequest(
+            global::Rosidl.Messages.UniqueIdentifier.UUID? @goalId = null
+        )
+        {
+            GoalId = @goalId ?? new global::Rosidl.Messages.UniqueIdentifier.UUID();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionGetResultServiceRequest"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionGetResultServiceRequest(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.GoalId = new global::Rosidl.Messages.UniqueIdentifier.UUID(in priv.GoalId, textEncoding);
+        }
+        
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.UniqueIdentifier.UUID GoalId { get; set; }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.GoalId.WriteTo(ref priv.GoalId, textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new LookupTransformActionGetResultServiceRequest(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native structure for <c>tf2_msgs/action/LookupTransform_GetResult_Request</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[unique_identifier_msgs/msg/UUID goal_id]]></c>
+            /// </summary>
+            public global::Rosidl.Messages.UniqueIdentifier.UUID.Priv GoalId;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.GoalId);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native sequence structure for <c>tf2_msgs/action/LookupTransform_GetResult_Request</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Request__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Message interface definition for <c>tf2_msgs/action/LookupTransform_GetResult_Response</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_GetResult_Response")]
+    internal unsafe partial class LookupTransformActionGetResultServiceResponse : global::Rosidl.Runtime.IServiceResponse
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_GetResult_Response";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__tf2_msgs__action__LookupTransform_GetResult_Response")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionGetResultServiceResponse"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='status'>
+        /// Originally defined as: <c><![CDATA[int8 status]]></c>
+        /// </param>
+        /// <param name='result'>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Result result]]></c>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionGetResultServiceResponse(
+            sbyte @status = 0,
+            global::Rosidl.Messages.Tf2.LookupTransformActionResult? @result = null
+        )
+        {
+            Status = @status;
+            Result = @result ?? new global::Rosidl.Messages.Tf2.LookupTransformActionResult();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionGetResultServiceResponse"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionGetResultServiceResponse(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Status = priv.Status;
+            this.Result = new global::Rosidl.Messages.Tf2.LookupTransformActionResult(in priv.Result, textEncoding);
+        }
+        
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[int8 status]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public sbyte Status { get; set; }
+        
+        /// <summary>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Result result]]></c>
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.LookupTransformActionResult Result { get; set; }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            priv.Status = this.Status;
+            this.Result.WriteTo(ref priv.Result, textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new LookupTransformActionGetResultServiceResponse(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native structure for <c>tf2_msgs/action/LookupTransform_GetResult_Response</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[int8 status]]></c>
+            /// </summary>
+            public sbyte Status;
+            
+            /// <summary>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_Result result]]></c>
+            /// </summary>
+            public global::Rosidl.Messages.Tf2.LookupTransformActionResult.Priv Result;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.Status);
+                __hashCode.Add(this.Result);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native sequence structure for <c>tf2_msgs/action/LookupTransform_GetResult_Response</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Response__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Simple API
+    /// </summary>
+    /// <remarks>
+    /// Message interface definition for <c>tf2_msgs/action/LookupTransform_GetResult_Event</c>.
+    /// </remarks>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/action/LookupTransform_GetResult_Event")]
+    internal unsafe partial class LookupTransformActionGetResultServiceEvent : global::Rosidl.Runtime.IServiceEvent
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/action/LookupTransform_GetResult_Event";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__tf2_msgs__action__LookupTransform_GetResult_Event")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionGetResultServiceEvent"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='info'>
+        /// Event info
+        /// Contains event type, timestamp, and request ID
+        /// <para>(originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>)</para>
+        /// </param>
+        /// <param name='request'>
+        /// The actual request content sent or received
+        /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// <para>(originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_GetResult_Request[<=1] request]]></c>)</para>
+        /// </param>
+        /// <param name='response'>
+        /// The actual response content sent or received
+        /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// <para>(originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_GetResult_Response[<=1] response]]></c>)</para>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionGetResultServiceEvent(
+            global::Rosidl.Messages.Service.ServiceEventInfo? @info = null,
+            global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest[]? @request = null,
+            global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse[]? @response = null
+        )
+        {
+            Info = @info ?? new global::Rosidl.Messages.Service.ServiceEventInfo();
+            Request = @request ?? global::System.Array.Empty<global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest>();
+            Response = @response ?? global::System.Array.Empty<global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse>();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="LookupTransformActionGetResultServiceEvent"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public LookupTransformActionGetResultServiceEvent(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Info = new global::Rosidl.Messages.Service.ServiceEventInfo(in priv.Info, textEncoding);
+        
+            this.Request = new global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest[priv.Request.Size];
+            var Request_span = priv.Request.AsSpan();
+            for (int __i = 0; __i < this.Request.Length; __i++)
+            {
+                this.Request[__i] = new global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest(in Request_span[__i], textEncoding);
+            }
+        
+            this.Response = new global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse[priv.Response.Size];
+            var Response_span = priv.Response.AsSpan();
+            for (int __i = 0; __i < this.Response.Length; __i++)
+            {
+                this.Response[__i] = new global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse(in Response_span[__i], textEncoding);
+            }
+        }
+        
+        
+        /// <summary>
+        /// Event info
+        /// Contains event type, timestamp, and request ID
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Service.ServiceEventInfo Info { get; set; }
+        
+        private global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest[] __backingField__Request;
+        
+        /// <summary>
+        /// The actual request content sent or received
+        /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_GetResult_Request[<=1] request]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest[] Request
+        {
+            get
+            {
+                return __backingField__Request;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__Request))]
+            set
+            {
+                __backingField__Request = value.Length <= 1 ? value : throw new global::System.ArgumentException("Size of the array or string 'Request' must be less or equal than 1.");
+            }
+        }
+        
+        private global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse[] __backingField__Response;
+        
+        /// <summary>
+        /// The actual response content sent or received
+        /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_GetResult_Response[<=1] response]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse[] Response
+        {
+            get
+            {
+                return __backingField__Response;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__Response))]
+            set
+            {
+                __backingField__Response = value.Length <= 1 ? value : throw new global::System.ArgumentException("Size of the array or string 'Response' must be less or equal than 1.");
+            }
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Info.WriteTo(ref priv.Info, textEncoding);
+            
+            priv.Request = new global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest.PrivSequence(this.Request.Length);
+            var Request_span = priv.Request.AsSpan();
+            for (int __i = 0; __i < this.Request.Length; __i++)
+            {
+                this.Request[__i].WriteTo(ref Request_span[__i], textEncoding);
+            }
+            
+            priv.Response = new global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse.PrivSequence(this.Response.Length);
+            var Response_span = priv.Response.AsSpan();
+            for (int __i = 0; __i < this.Response.Length; __i++)
+            {
+                this.Response[__i].WriteTo(ref Response_span[__i], textEncoding);
+            }
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new LookupTransformActionGetResultServiceEvent(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native structure for <c>tf2_msgs/action/LookupTransform_GetResult_Event</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Event info
+            /// Contains event type, timestamp, and request ID
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Service.ServiceEventInfo.Priv Info;
+            
+            /// <summary>
+            /// The actual request content sent or received
+            /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+            /// and the introspection feauture is configured to include payload data.
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_GetResult_Request[<=1] request]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceRequest.PrivSequence Request;
+            
+            /// <summary>
+            /// The actual response content sent or received
+            /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+            /// and the introspection feauture is configured to include payload data.
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/action/LookupTransform_GetResult_Response[<=1] response]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceResponse.PrivSequence Response;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.Info);
+                __hashCode.Add(this.Request);
+                __hashCode.Add(this.Response);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceEvent.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Simple API
+        /// </summary>
+        /// <remarks>
+        /// Blittable native sequence structure for <c>tf2_msgs/action/LookupTransform_GetResult_Event</c>.
+        /// </remarks>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__action__LookupTransform_GetResult_Event__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.LookupTransformActionGetResultServiceEvent.PrivSequence.{caller}'.");
                 }
             }
         }

--- a/src/Rcl.NET.Tests/Interfaces/Tf2/Messages/TF2Error.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Tf2/Messages/TF2Error.cs
@@ -20,11 +20,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class TF2Error : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/msg/TF2Error";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -44,7 +44,7 @@ namespace Rosidl.Messages.Tf2
         /// Originally defined as: <c><![CDATA[string error_string]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TF2Error(
             byte @error = 0,
             string @errorString = ""
@@ -61,7 +61,7 @@ namespace Rosidl.Messages.Tf2
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TF2Error(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Error = priv.Error;
@@ -108,25 +108,25 @@ namespace Rosidl.Messages.Tf2
         /// Originally defined as: <c><![CDATA[uint8 error]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public byte Error { get; set; }
         
         /// <summary>
         /// Originally defined as: <c><![CDATA[string error_string]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string ErrorString { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Error = this.Error;
@@ -134,49 +134,49 @@ namespace Rosidl.Messages.Tf2
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new TF2Error(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -199,21 +199,21 @@ namespace Rosidl.Messages.Tf2
             public global::Rosidl.Runtime.Interop.CString ErrorString;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -221,7 +221,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -229,28 +229,28 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -260,7 +260,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -270,18 +270,18 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -291,21 +291,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -316,7 +316,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -327,7 +327,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -341,7 +341,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -355,7 +355,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -369,7 +369,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -380,7 +380,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -408,28 +408,28 @@ namespace Rosidl.Messages.Tf2
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -437,7 +437,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -445,7 +445,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -453,21 +453,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -476,21 +476,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -500,7 +500,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -510,39 +510,39 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -553,7 +553,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -564,7 +564,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -578,7 +578,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -592,7 +592,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -606,7 +606,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -617,7 +617,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Tf2/Messages/TFMessage.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Tf2/Messages/TFMessage.cs
@@ -20,11 +20,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class TFMessage : global::Rosidl.Runtime.IMessage
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/msg/TFMessage";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -38,10 +38,10 @@ namespace Rosidl.Messages.Tf2
         /// Create a new instance of <see cref="TFMessage"/> with fields initialized to specified values.
         /// </summary>
         /// <param name='transforms'>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/TransformStamped[] transforms]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TransformStamped[] transforms]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TFMessage(
             global::Rosidl.Messages.Geometry.TransformStamped[]? @transforms = null
         )
@@ -56,7 +56,7 @@ namespace Rosidl.Messages.Tf2
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public TFMessage(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.Transforms = new global::Rosidl.Messages.Geometry.TransformStamped[priv.Transforms.Size];
@@ -69,21 +69,21 @@ namespace Rosidl.Messages.Tf2
         
         
         /// <summary>
-        /// Originally defined as: <c><![CDATA[geometry_msgs/TransformStamped[] transforms]]></c>
+        /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TransformStamped[] transforms]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public global::Rosidl.Messages.Geometry.TransformStamped[] Transforms { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.Transforms = new global::Rosidl.Messages.Geometry.TransformStamped.PrivSequence(this.Transforms.Length);
@@ -95,49 +95,49 @@ namespace Rosidl.Messages.Tf2
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new TFMessage(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -150,26 +150,26 @@ namespace Rosidl.Messages.Tf2
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             /// <summary>
-            /// Originally defined as: <c><![CDATA[geometry_msgs/TransformStamped[] transforms]]></c>
+            /// Originally defined as: <c><![CDATA[geometry_msgs/msg/TransformStamped[] transforms]]></c>
             /// </summary>
             public global::Rosidl.Messages.Geometry.TransformStamped.PrivSequence Transforms;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -177,7 +177,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -185,28 +185,28 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -216,7 +216,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -226,18 +226,18 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -246,21 +246,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -271,7 +271,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -282,7 +282,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -296,7 +296,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -310,7 +310,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -324,7 +324,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -335,7 +335,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -363,28 +363,28 @@ namespace Rosidl.Messages.Tf2
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -392,7 +392,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -400,7 +400,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -408,21 +408,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -431,21 +431,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -455,7 +455,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -465,39 +465,39 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -508,7 +508,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -519,7 +519,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -533,7 +533,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -547,7 +547,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -561,7 +561,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -572,7 +572,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {

--- a/src/Rcl.NET.Tests/Interfaces/Tf2/Services/FrameGraph.cs
+++ b/src/Rcl.NET.Tests/Interfaces/Tf2/Services/FrameGraph.cs
@@ -20,11 +20,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class FrameGraphService : global::Rosidl.Runtime.IService<FrameGraphServiceRequest, FrameGraphServiceResponse>
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/srv/FrameGraph";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Service);
@@ -42,11 +42,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class FrameGraphServiceRequest : global::Rosidl.Runtime.IServiceRequest
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/srv/FrameGraph_Request";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -60,7 +60,7 @@ namespace Rosidl.Messages.Tf2
         /// Create a new instance of <see cref="FrameGraphServiceRequest"/> with fields initialized to specified values.
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public FrameGraphServiceRequest() { }
         
         
@@ -70,69 +70,69 @@ namespace Rosidl.Messages.Tf2
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public FrameGraphServiceRequest(in Priv priv, global::System.Text.Encoding textEncoding)
         {
         }
         
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new FrameGraphServiceRequest(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -145,21 +145,21 @@ namespace Rosidl.Messages.Tf2
         public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
         {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -167,7 +167,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -175,28 +175,28 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -206,7 +206,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -216,18 +216,18 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -236,21 +236,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -261,7 +261,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -272,7 +272,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -286,7 +286,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -300,7 +300,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -314,7 +314,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -325,7 +325,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -353,28 +353,28 @@ namespace Rosidl.Messages.Tf2
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -382,7 +382,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -390,7 +390,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -398,21 +398,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -421,21 +421,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -445,7 +445,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -455,39 +455,39 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -498,7 +498,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -509,7 +509,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -523,7 +523,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -537,7 +537,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -551,7 +551,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -562,7 +562,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -581,11 +581,11 @@ namespace Rosidl.Messages.Tf2
     internal unsafe partial class FrameGraphServiceResponse : global::Rosidl.Runtime.IServiceResponse
     {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static string TypeSupportName => "tf2_msgs/srv/FrameGraph_Response";
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
         {
             return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
@@ -602,7 +602,7 @@ namespace Rosidl.Messages.Tf2
         /// Originally defined as: <c><![CDATA[string frame_yaml]]></c>
         /// </param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public FrameGraphServiceResponse(
             string @frameYaml = ""
         )
@@ -617,7 +617,7 @@ namespace Rosidl.Messages.Tf2
         /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
         /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public FrameGraphServiceResponse(in Priv priv, global::System.Text.Encoding textEncoding)
         {
             this.FrameYaml = global::Rosidl.Runtime.Interop.StringMarshal.CreatePooledString(priv.FrameYaml.AsSpan(), textEncoding);
@@ -628,67 +628,67 @@ namespace Rosidl.Messages.Tf2
         /// Originally defined as: <c><![CDATA[string frame_yaml]]></c>
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public string FrameYaml { get; set; }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
         {
             WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
         {
             priv.FrameYaml.CopyFrom(this.FrameYaml, textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
         {
             return new FrameGraphServiceResponse(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static nint UnsafeCreate()
         {
             return new(Priv.Create());
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeDestroy(nint data)
         {
             Priv.Destroy((Priv*)data);
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitialize(nint data)
         {
             return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalize(nint data)
         {
             Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static bool UnsafeInitializeSequence(int size, nint data)
         {
             return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
         }
         
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
         public static void UnsafeFinalizeSequence(nint data)
         {
             PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
@@ -706,21 +706,21 @@ namespace Rosidl.Messages.Tf2
             public global::Rosidl.Runtime.Interop.CString FrameYaml;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv()
             {
                 ThrowIfNonSuccess(TryInitialize(out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(in Priv src)
                 : this()
             {
@@ -728,7 +728,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public Priv(Priv* src)
                 : this()
             {
@@ -736,28 +736,28 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in Priv src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(Priv* src)
             {
                 fixed (Priv* pThis = &this)
@@ -767,7 +767,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in Priv input, out Priv output)
             {
                 fixed (Priv* pInput = &input, pOutput = &output)
@@ -777,18 +777,18 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(Priv other)
             {
                 return Priv.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 var __hashCode = new global::System.HashCode();
@@ -797,21 +797,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(Priv lhs, Priv rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(Priv lhs, Priv rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static Priv* Create()
             {
                 return _PInvoke();
@@ -822,7 +822,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(Priv* msg)
             {
                 _PInvoke(msg);
@@ -833,7 +833,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(out Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -847,7 +847,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref Priv msg)
             {
                 fixed (Priv* pMsg = &msg)
@@ -861,7 +861,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in Priv lhs, in Priv rhs)
             {
                 fixed (Priv* plhs = &lhs, prhs = &rhs)
@@ -875,7 +875,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(Priv* input, Priv* output)
             {
                 return _PInvoke(input, output);
@@ -886,7 +886,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
@@ -914,28 +914,28 @@ namespace Rosidl.Messages.Tf2
             public int Capcacity => (int)__capacity;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence()
                 : this(0)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(int size)
             {
                 ThrowIfNonSuccess(TryInitialize(size, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence src)
                 : this(in src)
             {
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(in PrivSequence src)
                 : this()
             {
@@ -943,7 +943,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(PrivSequence* src)
                 : this()
             {
@@ -951,7 +951,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public PrivSequence(System.ReadOnlySpan<Priv> src)
                 : this(src.Length)
             {
@@ -959,21 +959,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void Dispose()
             {
                 Finalize(ref this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public System.Span<Priv> AsSpan()
             {
                 return new(__data, Size);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(System.ReadOnlySpan<Priv> src)
             {
                 Finalize(ref this);
@@ -982,21 +982,21 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(in PrivSequence src)
             {
                 ThrowIfNonSuccess(TryCopy(in src, out this));
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public void CopyFrom(PrivSequence* src)
             {
                 fixed (PrivSequence* pThis = &this)
@@ -1006,7 +1006,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(in PrivSequence input, out PrivSequence output)
             {
                 fixed (PrivSequence* pInput = &input, pOutput = &output)
@@ -1016,39 +1016,39 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public bool Equals(PrivSequence other)
             {
                 return PrivSequence.AreEqual(in other, in this);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public override int GetHashCode()
             {
                 return global::System.HashCode.Combine((nint)__data, __size, __capacity);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
             {
                 return lhs.Equals(rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
             {
                 return !(lhs == rhs);
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static PrivSequence* Create()
             {
                 return _PInvoke();
@@ -1059,7 +1059,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Destroy(PrivSequence* msg)
             {
                 _PInvoke(msg);
@@ -1070,7 +1070,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static bool TryInitialize(int size, out PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1084,7 +1084,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void Finalize(ref PrivSequence msg)
             {
                 fixed (PrivSequence* pMsg = &msg)
@@ -1098,7 +1098,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
             {
                 fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
@@ -1112,7 +1112,7 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             private static bool TryCopy(PrivSequence* input, PrivSequence* output)
             {
                 return _PInvoke(input, output);
@@ -1123,13 +1123,700 @@ namespace Rosidl.Messages.Tf2
             }
             
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Rosidl.Runtime.Generator.CSharp", "1.0.0")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
             public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
             string caller = "")
             {
                 if (!ret)
                 {
                     throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.FrameGraphServiceResponse.PrivSequence.{caller}'.");
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Message interface definition for <c>tf2_msgs/srv/FrameGraph_Event</c>.
+    /// </summary>
+    [global::Rosidl.Runtime.TypeSupportAttribute("tf2_msgs/srv/FrameGraph_Event")]
+    internal unsafe partial class FrameGraphServiceEvent : global::Rosidl.Runtime.IServiceEvent
+    {
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static string TypeSupportName => "tf2_msgs/srv/FrameGraph_Event";
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.TypeSupportHandle GetTypeSupportHandle()
+        {
+            return new global::Rosidl.Runtime.TypeSupportHandle(_PInvoke(), global::Rosidl.Runtime.HandleType.Message);
+            
+            [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+            [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_typesupport_c", EntryPoint = "rosidl_typesupport_c__get_message_type_support_handle__tf2_msgs__srv__FrameGraph_Event")]
+            static extern nint _PInvoke();
+        }
+        
+        /// <summary>
+        /// Create a new instance of <see cref="FrameGraphServiceEvent"/> with fields initialized to specified values.
+        /// </summary>
+        /// <param name='info'>
+        /// Event info
+        /// Contains event type, timestamp, and request ID
+        /// <para>(originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>)</para>
+        /// </param>
+        /// <param name='request'>
+        /// The actual request content sent or received
+        /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// <para>(originally defined as: <c><![CDATA[tf2_msgs/srv/FrameGraph_Request[<=1] request]]></c>)</para>
+        /// </param>
+        /// <param name='response'>
+        /// The actual response content sent or received
+        /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// <para>(originally defined as: <c><![CDATA[tf2_msgs/srv/FrameGraph_Response[<=1] response]]></c>)</para>
+        /// </param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public FrameGraphServiceEvent(
+            global::Rosidl.Messages.Service.ServiceEventInfo? @info = null,
+            global::Rosidl.Messages.Tf2.FrameGraphServiceRequest[]? @request = null,
+            global::Rosidl.Messages.Tf2.FrameGraphServiceResponse[]? @response = null
+        )
+        {
+            Info = @info ?? new global::Rosidl.Messages.Service.ServiceEventInfo();
+            Request = @request ?? global::System.Array.Empty<global::Rosidl.Messages.Tf2.FrameGraphServiceRequest>();
+            Response = @response ?? global::System.Array.Empty<global::Rosidl.Messages.Tf2.FrameGraphServiceResponse>();
+        }
+        
+        
+        /// <summary>
+        /// Create a new instance of <see cref="FrameGraphServiceEvent"/>, and copy its data from the specified <see cref="Priv"/> structure.
+        /// </summary>
+        /// <param name="priv">The <see cref="Priv"/> structure to be copied from.</param>
+        /// <param name="textEncoding">Text encoding of the strings in the <see cref="Priv"/> structure and its containing structures, if any.</param>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public FrameGraphServiceEvent(in Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Info = new global::Rosidl.Messages.Service.ServiceEventInfo(in priv.Info, textEncoding);
+        
+            this.Request = new global::Rosidl.Messages.Tf2.FrameGraphServiceRequest[priv.Request.Size];
+            var Request_span = priv.Request.AsSpan();
+            for (int __i = 0; __i < this.Request.Length; __i++)
+            {
+                this.Request[__i] = new global::Rosidl.Messages.Tf2.FrameGraphServiceRequest(in Request_span[__i], textEncoding);
+            }
+        
+            this.Response = new global::Rosidl.Messages.Tf2.FrameGraphServiceResponse[priv.Response.Size];
+            var Response_span = priv.Response.AsSpan();
+            for (int __i = 0; __i < this.Response.Length; __i++)
+            {
+                this.Response[__i] = new global::Rosidl.Messages.Tf2.FrameGraphServiceResponse(in Response_span[__i], textEncoding);
+            }
+        }
+        
+        
+        /// <summary>
+        /// Event info
+        /// Contains event type, timestamp, and request ID
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Service.ServiceEventInfo Info { get; set; }
+        
+        private global::Rosidl.Messages.Tf2.FrameGraphServiceRequest[] __backingField__Request;
+        
+        /// <summary>
+        /// The actual request content sent or received
+        /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/srv/FrameGraph_Request[<=1] request]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.FrameGraphServiceRequest[] Request
+        {
+            get
+            {
+                return __backingField__Request;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__Request))]
+            set
+            {
+                __backingField__Request = value.Length <= 1 ? value : throw new global::System.ArgumentException("Size of the array or string 'Request' must be less or equal than 1.");
+            }
+        }
+        
+        private global::Rosidl.Messages.Tf2.FrameGraphServiceResponse[] __backingField__Response;
+        
+        /// <summary>
+        /// The actual response content sent or received
+        /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+        /// and the introspection feauture is configured to include payload data.
+        /// </summary>
+        /// <remarks>
+        /// Originally defined as: <c><![CDATA[tf2_msgs/srv/FrameGraph_Response[<=1] response]]></c>
+        /// </remarks>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public global::Rosidl.Messages.Tf2.FrameGraphServiceResponse[] Response
+        {
+            get
+            {
+                return __backingField__Response;
+            }
+            [global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(__backingField__Response))]
+            set
+            {
+                __backingField__Response = value.Length <= 1 ? value : throw new global::System.ArgumentException("Size of the array or string 'Response' must be less or equal than 1.");
+            }
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(nint data, global::System.Text.Encoding textEncoding)
+        {
+            WriteTo(ref global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public void WriteTo(ref Priv priv, global::System.Text.Encoding textEncoding)
+        {
+            this.Info.WriteTo(ref priv.Info, textEncoding);
+            
+            priv.Request = new global::Rosidl.Messages.Tf2.FrameGraphServiceRequest.PrivSequence(this.Request.Length);
+            var Request_span = priv.Request.AsSpan();
+            for (int __i = 0; __i < this.Request.Length; __i++)
+            {
+                this.Request[__i].WriteTo(ref Request_span[__i], textEncoding);
+            }
+            
+            priv.Response = new global::Rosidl.Messages.Tf2.FrameGraphServiceResponse.PrivSequence(this.Response.Length);
+            var Response_span = priv.Response.AsSpan();
+            for (int __i = 0; __i < this.Response.Length; __i++)
+            {
+                this.Response[__i].WriteTo(ref Response_span[__i], textEncoding);
+            }
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static global::Rosidl.Runtime.IMessage CreateFrom(nint data, global::System.Text.Encoding textEncoding)
+        {
+            return new FrameGraphServiceEvent(in global::System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()), textEncoding);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static nint UnsafeCreate()
+        {
+            return new(Priv.Create());
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeDestroy(nint data)
+        {
+            Priv.Destroy((Priv*)data);
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitialize(nint data)
+        {
+            return Priv.TryInitialize(out System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalize(nint data)
+        {
+            Priv.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<Priv>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static bool UnsafeInitializeSequence(int size, nint data)
+        {
+            return PrivSequence.TryInitialize(size, out System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+        public static void UnsafeFinalizeSequence(nint data)
+        {
+            PrivSequence.Finalize(ref System.Runtime.CompilerServices.Unsafe.AsRef<PrivSequence>(data.ToPointer()));
+        }
+        
+        /// <summary>
+        /// Blittable native structure for <c>tf2_msgs/srv/FrameGraph_Event</c>.
+        /// </summary>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Priv : global::System.IEquatable<Priv>, global::System.IDisposable
+        {
+            /// <summary>
+            /// Event info
+            /// Contains event type, timestamp, and request ID
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[service_msgs/msg/ServiceEventInfo info]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Service.ServiceEventInfo.Priv Info;
+            
+            /// <summary>
+            /// The actual request content sent or received
+            /// This field is only set if the event type is REQUEST_SENT or REQUEST_RECEIVED,
+            /// and the introspection feauture is configured to include payload data.
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/srv/FrameGraph_Request[<=1] request]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Tf2.FrameGraphServiceRequest.PrivSequence Request;
+            
+            /// <summary>
+            /// The actual response content sent or received
+            /// This field is only set if the event type is RESPONSE_SENT or RESPONSE_RECEIVED,
+            /// and the introspection feauture is configured to include payload data.
+            /// </summary>
+            /// <remarks>
+            /// Originally defined as: <c><![CDATA[tf2_msgs/srv/FrameGraph_Response[<=1] response]]></c>
+            /// </remarks>
+            public global::Rosidl.Messages.Tf2.FrameGraphServiceResponse.PrivSequence Response;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv()
+            {
+                ThrowIfNonSuccess(TryInitialize(out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(in Priv src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public Priv(Priv* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in Priv src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(Priv* src)
+            {
+                fixed (Priv* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in Priv input, out Priv output)
+            {
+                fixed (Priv* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(Priv other)
+            {
+                return Priv.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is Priv s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                var __hashCode = new global::System.HashCode();
+                __hashCode.Add(this.Info);
+                __hashCode.Add(this.Request);
+                __hashCode.Add(this.Response);
+                return __hashCode.ToHashCode();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(Priv lhs, Priv rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(Priv lhs, Priv rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static Priv* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__create")]
+                static extern Priv* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(Priv* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__destroy")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(out Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__init")]
+                static extern bool _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref Priv msg)
+            {
+                fixed (Priv* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__fini")]
+                static extern void _PInvoke(Priv* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in Priv lhs, in Priv rhs)
+            {
+                fixed (Priv* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__are_qual")]
+                static extern bool _PInvoke(Priv* lhs, Priv* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(Priv* input, Priv* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__copy")]
+                static extern bool _PInvoke(Priv* input, Priv* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.FrameGraphServiceEvent.Priv.{caller}'.");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Blittable native sequence structure for <c>tf2_msgs/srv/FrameGraph_Event</c>.
+        /// </summary>
+        [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct PrivSequence : global::System.IEquatable<PrivSequence>, global::System.IDisposable
+        {
+            private Priv* __data;
+            
+            private nuint __size;
+            
+            private nuint __capacity;
+            
+            public int Size => (int)__size;
+            
+            public int Capcacity => (int)__capacity;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence()
+                : this(0)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(int size)
+            {
+                ThrowIfNonSuccess(TryInitialize(size, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence src)
+                : this(in src)
+            {
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(in PrivSequence src)
+                : this()
+            {
+                CopyFrom(in src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(PrivSequence* src)
+                : this()
+            {
+                CopyFrom(src); 
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public PrivSequence(System.ReadOnlySpan<Priv> src)
+                : this(src.Length)
+            {
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void Dispose()
+            {
+                Finalize(ref this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public System.Span<Priv> AsSpan()
+            {
+                return new(__data, Size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(System.ReadOnlySpan<Priv> src)
+            {
+                Finalize(ref this);
+                ThrowIfNonSuccess(TryInitialize(src.Length, out this));
+                src.CopyTo(AsSpan());
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(in PrivSequence src)
+            {
+                ThrowIfNonSuccess(TryCopy(in src, out this));
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public void CopyFrom(PrivSequence* src)
+            {
+                fixed (PrivSequence* pThis = &this)
+                {
+                    ThrowIfNonSuccess(TryCopy(src, pThis));
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(in PrivSequence input, out PrivSequence output)
+            {
+                fixed (PrivSequence* pInput = &input, pOutput = &output)
+                {
+                    return TryCopy(pInput, pOutput);
+                }
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public bool Equals(PrivSequence other)
+            {
+                return PrivSequence.AreEqual(in other, in this);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override bool Equals(object? obj) => obj is PrivSequence s ? this.Equals(s) : false;
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public override int GetHashCode()
+            {
+                return global::System.HashCode.Combine((nint)__data, __size, __capacity);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator ==(PrivSequence lhs, PrivSequence rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool operator !=(PrivSequence lhs, PrivSequence rhs)
+            {
+                return !(lhs == rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static PrivSequence* Create()
+            {
+                return _PInvoke();
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__Sequence__create")]
+                static extern PrivSequence* _PInvoke();
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Destroy(PrivSequence* msg)
+            {
+                _PInvoke(msg);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__Sequence__destroy")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static bool TryInitialize(int size, out PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    return _PInvoke(pMsg, (uint)size);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__Sequence__init")]
+                static extern bool _PInvoke(PrivSequence* msg, nuint size);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void Finalize(ref PrivSequence msg)
+            {
+                fixed (PrivSequence* pMsg = &msg)
+                {
+                    _PInvoke(pMsg);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__Sequence__fini")]
+                static extern void _PInvoke(PrivSequence* msg);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool AreEqual(in PrivSequence lhs, in PrivSequence rhs)
+            {
+                fixed (PrivSequence* plhs = &lhs, prhs = &rhs)
+                {
+                    return _PInvoke(plhs, prhs);
+                }
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__Sequence__are_qual")]
+                static extern bool _PInvoke(PrivSequence* lhs, PrivSequence* rhs);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            private static bool TryCopy(PrivSequence* input, PrivSequence* output)
+            {
+                return _PInvoke(input, output);
+                
+                [global::System.Runtime.InteropServices.SuppressGCTransitionAttribute]
+                [global::System.Runtime.InteropServices.DllImportAttribute("tf2_msgs__rosidl_generator_c", EntryPoint = "tf2_msgs__srv__FrameGraph_Event__Sequence__copy")]
+                static extern bool _PInvoke(PrivSequence* input, PrivSequence* output);
+            }
+            
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ros2cs", "1.0.0")]
+            public static void ThrowIfNonSuccess(bool ret, [global::System.Runtime.CompilerServices.CallerMemberNameAttribute]
+            string caller = "")
+            {
+                if (!ret)
+                {
+                    throw new global::Rosidl.Runtime.RosidlException($"An error occurred when calling 'global::Rosidl.Messages.Tf2.FrameGraphServiceEvent.PrivSequence.{caller}'.");
                 }
             }
         }

--- a/src/Rcl.NET.Tests/RosGraphTests.cs
+++ b/src/Rcl.NET.Tests/RosGraphTests.cs
@@ -152,9 +152,12 @@ public class RosGraphTests
             node.Graph.WatchAsync((graph, e) => graph.Topics.Any(x => x.Name == targetTopic), 100));
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task PublisherGid()
     {
+        // TODO: Track https://github.com/ros2/rmw_cyclonedds/issues/446
+        Skip.If(RosEnvironment.RmwImplementationIdentifier == "rmw_cyclonedds_cpp", "rmw_get_gid_for_publisher is broken in 'rmw_cyclonedds_cpp'.");
+
         await using var ctx = new RclContext(TestConfig.DefaultContextArguments);
         using var node = ctx.CreateNode(NameGenerator.GenerateNodeName());
 

--- a/src/Rcl.NET.Tests/RosGraphTests.cs
+++ b/src/Rcl.NET.Tests/RosGraphTests.cs
@@ -176,7 +176,7 @@ public class RosGraphTests
         try
         {
             Assert.True(await watcher);
-            Assert.Equal(node.Graph.Topics.First(x => x.Name == topic).Publishers.First().Gid, await gidTask.Task);
+            Assert.Equal(node.Graph.Topics.Single(x => x.Name == topic).Publishers.Single().Gid, await gidTask.Task);
         }
         finally
         {

--- a/src/Rcl.NET.Tests/ServiceTests.cs
+++ b/src/Rcl.NET.Tests/ServiceTests.cs
@@ -173,4 +173,19 @@ public class ServiceTests
 
         Assert.Equal(cts.Token, ex.CancellationToken);
     }
+
+    [SkippableFact]
+    public async Task ClientGid()
+    {
+        Skip.If(!RosEnvironment.IsSupported(RosEnvironment.Iron), "Service introspection is only supported on iron and later.");
+
+        await using var context = new RclContext(TestConfig.DefaultContextArguments);
+        using var node = context.CreateNode(NameGenerator.GenerateNodeName());
+        using var client = node.CreateClient<
+            ListParametersService,
+            ListParametersServiceRequest,
+            ListParametersServiceResponse>(NameGenerator.GenerateServiceName());
+
+        Assert.NotEqual(GraphId.Empty, client.Gid);
+    }
 }

--- a/src/Rcl.NET.Tests/iron.Dockerfile
+++ b/src/Rcl.NET.Tests/iron.Dockerfile
@@ -1,15 +1,14 @@
-FROM ros:rolling-ros-core
+FROM ros:iron-ros-core
 RUN echo "from urllib import request\nrequest.urlretrieve('https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb', 'packages-microsoft-prod.deb')" | python3  \
     && dpkg -i packages-microsoft-prod.deb \
     && rm packages-microsoft-prod.deb \
     && apt-get update \
     && apt-get -y install --no-install-recommends \
-       ros-rolling-rmw-cyclonedds-cpp \
-       ros-rolling-rmw-fastrtps-cpp \
-       ros-rolling-tf2-msgs \
+       ros-iron-rmw-cyclonedds-cpp \
+       ros-iron-rmw-fastrtps-cpp \
+       ros-iron-tf2-msgs \
        dotnet-runtime-7.0 \
-       ros-rolling-service-msgs \
-    && apt-get install -y --only-upgrade ros-rolling-* \
+       ros-iron-service-msgs \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/src/Rcl.NET.Tests/iron.Dockerfile
+++ b/src/Rcl.NET.Tests/iron.Dockerfile
@@ -1,0 +1,15 @@
+FROM ros:rolling-ros-core
+RUN echo "from urllib import request\nrequest.urlretrieve('https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb', 'packages-microsoft-prod.deb')" | python3  \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends \
+       ros-rolling-rmw-cyclonedds-cpp \
+       ros-rolling-rmw-fastrtps-cpp \
+       ros-rolling-tf2-msgs \
+       dotnet-runtime-7.0 \
+       ros-rolling-service-msgs \
+    && apt-get install -y --only-upgrade ros-rolling-* \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/Rcl.NET.Tests/ros2cs.spec
+++ b/src/Rcl.NET.Tests/ros2cs.spec
@@ -1,8 +1,11 @@
 output ./Interfaces
 
 internal
+service-introspection on
+action-details on
 
 from-ament-index
+from-directory packages
 
 include std_msgs geometry_msgs sensor_msgs tf2_msgs
-exclude builtin_interfaces
+exclude builtin_interfaces unique_identifier_msgs

--- a/src/Rcl.NET.Tests/ubuntu.iron.cyclonedds.runsettings
+++ b/src/Rcl.NET.Tests/ubuntu.iron.cyclonedds.runsettings
@@ -2,12 +2,12 @@
 <RunSettings>
   <RunConfiguration>
     <EnvironmentVariables>
-      <ROS_DISTRO>rolling</ROS_DISTRO>
+      <ROS_DISTRO>iron</ROS_DISTRO>
       <ROS_LOCALHOST_ONLY>0</ROS_LOCALHOST_ONLY>
       <ROS_PYTHON_VERSION>3</ROS_PYTHON_VERSION>
       <ROS_VERSION>2</ROS_VERSION>
-      <LD_LIBRARY_PATH>/opt/ros/rolling/lib/x86_64-linux-gnu:/opt/ros/rolling/lib</LD_LIBRARY_PATH>
-      <AMENT_PREFIX_PATH>/opt/ros/rolling</AMENT_PREFIX_PATH>
+      <LD_LIBRARY_PATH>/opt/ros/iron/lib/x86_64-linux-gnu:/opt/ros/iron/lib</LD_LIBRARY_PATH>
+      <AMENT_PREFIX_PATH>/opt/ros/iron</AMENT_PREFIX_PATH>
       <RMW_IMPLEMENTATION>rmw_cyclonedds_cpp</RMW_IMPLEMENTATION>
     </EnvironmentVariables>
   </RunConfiguration>

--- a/src/Rcl.NET.Tests/ubuntu.iron.cyclonedds.runsettings
+++ b/src/Rcl.NET.Tests/ubuntu.iron.cyclonedds.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <ROS_DISTRO>rolling</ROS_DISTRO>
+      <ROS_LOCALHOST_ONLY>0</ROS_LOCALHOST_ONLY>
+      <ROS_PYTHON_VERSION>3</ROS_PYTHON_VERSION>
+      <ROS_VERSION>2</ROS_VERSION>
+      <LD_LIBRARY_PATH>/opt/ros/rolling/lib/x86_64-linux-gnu:/opt/ros/rolling/lib</LD_LIBRARY_PATH>
+      <AMENT_PREFIX_PATH>/opt/ros/rolling</AMENT_PREFIX_PATH>
+      <RMW_IMPLEMENTATION>rmw_cyclonedds_cpp</RMW_IMPLEMENTATION>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/src/Rcl.NET.Tests/ubuntu.iron.fastrtps.runsettings
+++ b/src/Rcl.NET.Tests/ubuntu.iron.fastrtps.runsettings
@@ -2,12 +2,12 @@
 <RunSettings>
   <RunConfiguration>
     <EnvironmentVariables>
-      <ROS_DISTRO>rolling</ROS_DISTRO>
+      <ROS_DISTRO>iron</ROS_DISTRO>
       <ROS_LOCALHOST_ONLY>0</ROS_LOCALHOST_ONLY>
       <ROS_PYTHON_VERSION>3</ROS_PYTHON_VERSION>
       <ROS_VERSION>2</ROS_VERSION>
-      <LD_LIBRARY_PATH>/opt/ros/rolling/lib/x86_64-linux-gnu:/opt/ros/rolling/lib</LD_LIBRARY_PATH>
-      <AMENT_PREFIX_PATH>/opt/ros/rolling</AMENT_PREFIX_PATH>
+      <LD_LIBRARY_PATH>/opt/ros/iron/lib/x86_64-linux-gnu:/opt/ros/iron/lib</LD_LIBRARY_PATH>
+      <AMENT_PREFIX_PATH>/opt/ros/iron</AMENT_PREFIX_PATH>
       <RMW_IMPLEMENTATION>rmw_fastrtps_cpp</RMW_IMPLEMENTATION>
     </EnvironmentVariables>
   </RunConfiguration>

--- a/src/Rcl.NET.Tests/ubuntu.iron.fastrtps.runsettings
+++ b/src/Rcl.NET.Tests/ubuntu.iron.fastrtps.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <ROS_DISTRO>rolling</ROS_DISTRO>
+      <ROS_LOCALHOST_ONLY>0</ROS_LOCALHOST_ONLY>
+      <ROS_PYTHON_VERSION>3</ROS_PYTHON_VERSION>
+      <ROS_VERSION>2</ROS_VERSION>
+      <LD_LIBRARY_PATH>/opt/ros/rolling/lib/x86_64-linux-gnu:/opt/ros/rolling/lib</LD_LIBRARY_PATH>
+      <AMENT_PREFIX_PATH>/opt/ros/rolling</AMENT_PREFIX_PATH>
+      <RMW_IMPLEMENTATION>rmw_fastrtps_cpp</RMW_IMPLEMENTATION>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/src/Rcl.NET/Actions/Options.cs
+++ b/src/Rcl.NET/Actions/Options.cs
@@ -74,7 +74,7 @@ public record ActionClientOptions
         QosProfile? feedbackTopicQos = null,
         QosProfile? statusTopicQos = null,
         Encoding? textEncoding = null,
-        int queueSize = 1,
+        int queueSize = 64,
         BoundedChannelFullMode fullMode = BoundedChannelFullMode.DropOldest,
         bool allowSynchronousContinuations = false)
     {

--- a/src/Rcl.NET/Graph/RosGraph.cs
+++ b/src/Rcl.NET/Graph/RosGraph.cs
@@ -404,7 +404,7 @@ public partial class RosGraph : IGraphBuilder, IObservable<RosGraphEvent>
             {
                 ref var item = ref src->info_array[i];
                 dest[i] = new(
-                    new(new ReadOnlySpan<byte>(src->info_array[i].endpoint_gid, 24)),
+                    new(src->info_array[i].GetGidSpan()),
                     StringMarshal.CreatePooledString(item.topic_type)!,
                     new(
                         StringMarshal.CreatePooledString(item.node_name)!,
@@ -429,7 +429,7 @@ public partial class RosGraph : IGraphBuilder, IObservable<RosGraphEvent>
             {
                 ref var item = ref src->info_array[i];
                 dest[i] = new(
-                    new(item.endpoint_gid),
+                    new(item.GetGidSpan()),
                     StringMarshal.CreatePooledString(item.topic_type)!,
                     new(
                         StringMarshal.CreatePooledString(item.node_name)!,

--- a/src/Rcl.NET/Graph/RosGraph.cs
+++ b/src/Rcl.NET/Graph/RosGraph.cs
@@ -404,7 +404,7 @@ public partial class RosGraph : IGraphBuilder, IObservable<RosGraphEvent>
             {
                 ref var item = ref src->info_array[i];
                 dest[i] = new(
-                    new(src->info_array[i].endpoint_gid),
+                    new(new ReadOnlySpan<byte>(src->info_array[i].endpoint_gid, 24)),
                     StringMarshal.CreatePooledString(item.topic_type)!,
                     new(
                         StringMarshal.CreatePooledString(item.node_name)!,

--- a/src/Rcl.NET/Graph/RosTopic.cs
+++ b/src/Rcl.NET/Graph/RosTopic.cs
@@ -68,7 +68,7 @@ public class RosTopic
                 nodes.TryGetValue(ep.Node, out var node))
             {
                 var endpoint = new RosTopicEndPoint(
-                    this, node, type, ep.Type, ep.QosProfile);
+                   ep.Id, this, node, type, ep.Type, ep.QosProfile);
 
                 dest[ep.Id] = endpoint;
                 if (type is TopicEndPointType.Publisher)

--- a/src/Rcl.NET/Graph/RosTopicEndPoint.cs
+++ b/src/Rcl.NET/Graph/RosTopicEndPoint.cs
@@ -21,12 +21,14 @@ public enum TopicEndPointType
 /// <summary>
 /// Represents an endpoint of a ROS topic.
 /// </summary>
+/// <param name="Gid">Globally unique identifier of the endpoint.</param>
 /// <param name="Topic">The topic which the endpoint is publishing or subscribed to.</param>
 /// <param name="Node">The node which created the endpoint.</param>
 /// <param name="EndPointType">Type of the topic endpoint.</param>
 /// <param name="Type">Message type of the publication or subscription.</param>
 /// <param name="QosProfile">QoS profile of  publication or subscription.</param>
 public record RosTopicEndPoint(
+    GraphId Gid,
     RosTopic Topic,
     RosNode Node,
     TopicEndPointType EndPointType,

--- a/src/Rcl.NET/Graph/TopicEndPointData.cs
+++ b/src/Rcl.NET/Graph/TopicEndPointData.cs
@@ -1,6 +1,4 @@
 using Rcl.Qos;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Rcl.Graph;
 
@@ -11,52 +9,3 @@ record struct TopicEndPointData(
     string Type,
     NodeName Node,
     QosProfile QosProfile);
-
-internal struct GraphId : IEquatable<GraphId>
-{
-    // These fields are initialized by directly copying the struct.
-#pragma warning disable CS0649
-    private readonly long _d1, _d2, _d3;
-#pragma warning restore CS0649
-
-    public GraphId(ReadOnlySpan<byte> data)
-    {
-        this = MemoryMarshal.Cast<byte, GraphId>(data)[0];
-    }
-
-    /// <summary>
-    /// This is for iron or later, as the size of the GID is changed from 24 to 16 bytes.
-    /// </summary>
-    /// <param name="guid"></param>
-    public unsafe GraphId(Guid guid)
-    {
-        Unsafe.AsRef<Guid>(Unsafe.AsPointer(ref this)) = guid;
-    }
-
-    public unsafe GraphId(byte* data)
-        : this(new ReadOnlySpan<byte>(data, sizeof(GraphId)))
-    { }
-
-    public override bool Equals(object? obj)
-    {
-        if (obj is GraphId other)
-        {
-            return Equals(other);
-        }
-        return false;
-    }
-
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(_d1, _d2, _d3);
-    }
-
-    public static bool operator ==(GraphId a, GraphId b)
-        => a.Equals(b);
-
-    public static bool operator !=(GraphId a, GraphId b)
-        => !(a == b);
-
-    public bool Equals(GraphId other)
-        => _d1 == other._d1 && _d2 == other._d2 && _d3 == other._d3;
-}

--- a/src/Rcl.NET/Graph/TopicEndPointData.cs
+++ b/src/Rcl.NET/Graph/TopicEndPointData.cs
@@ -1,4 +1,5 @@
 using Rcl.Qos;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Rcl.Graph;
@@ -21,6 +22,15 @@ internal struct GraphId : IEquatable<GraphId>
     public GraphId(ReadOnlySpan<byte> data)
     {
         this = MemoryMarshal.Cast<byte, GraphId>(data)[0];
+    }
+
+    /// <summary>
+    /// This is for iron or later, as the size of the GID is changed from 24 to 16 bytes.
+    /// </summary>
+    /// <param name="guid"></param>
+    public unsafe GraphId(Guid guid)
+    {
+        Unsafe.AsRef<Guid>(Unsafe.AsPointer(ref this)) = guid;
     }
 
     public unsafe GraphId(byte* data)

--- a/src/Rcl.NET/GraphId.cs
+++ b/src/Rcl.NET/GraphId.cs
@@ -12,13 +12,21 @@ public unsafe struct GraphId : IEquatable<GraphId>
     private byte _data;
 
     [FieldOffset(0)]
-    private long _data0;
+    private readonly long _data0;
 
     [FieldOffset(8)]
-    private long _data1;
+    private readonly long _data1;
 
     [FieldOffset(16)]
-    private long _data2;
+    private readonly long _data2;
+
+    /// <summary>
+    /// Number of effective bytes of the <see cref="GraphId"/> structure for current ROS distribution.
+    /// </summary>
+    /// <remarks>
+    /// The value of the field is 16 for <see cref="RosEnvironment.Iron"/> or newer distributions, and 24 for earlier distributions.
+    /// </remarks>
+    public static readonly int Size = RosEnvironment.IsSupported(RosEnvironment.Iron) ? 16 : 24;
 
     private Span<byte> AsSpan()
         => MemoryMarshal.CreateSpan(ref _data, 24);

--- a/src/Rcl.NET/GraphId.cs
+++ b/src/Rcl.NET/GraphId.cs
@@ -5,17 +5,23 @@ namespace Rcl;
 /// <summary>
 /// Represents a unique identifier for ROS communication entities.
 /// </summary>
+[StructLayout(LayoutKind.Explicit)]
 public unsafe struct GraphId : IEquatable<GraphId>
 {
-    private fixed byte _data[24];
+    [FieldOffset(0)]
+    private byte _data;
+
+    [FieldOffset(0)]
+    private long _data0;
+
+    [FieldOffset(8)]
+    private long _data1;
+
+    [FieldOffset(16)]
+    private long _data2;
 
     private Span<byte> AsSpan()
-    {
-        fixed (void* p = _data)
-        {
-            return new(p, 24);
-        }
-    }
+        => MemoryMarshal.CreateSpan(ref _data, 24);
 
     /// <summary>
     /// Create a new <see cref="GraphId"/> with its value copied from a <see cref="ReadOnlySpan{Byte}"/>.
@@ -23,7 +29,7 @@ public unsafe struct GraphId : IEquatable<GraphId>
     /// <param name="data">The <see cref="ReadOnlySpan{Byte}"/> to be copied from. The size of the <paramref name="data"/> must be either 16 or 24 bytes.</param>
     public unsafe GraphId(ReadOnlySpan<byte> data)
     {
-        if (data.Length != 16 || data.Length != 24)
+        if (data.Length != 16 && data.Length != 24)
         {
             throw new ArgumentException($"Size of the GID data must be either 16 or 24 bytes.");
         }
@@ -75,9 +81,10 @@ public unsafe struct GraphId : IEquatable<GraphId>
     public override string ToString()
     {
         Span<char> output = stackalloc char[24 * 2];
+        var data = AsSpan();
         for (int i = 0; i < 24; i++)
         {
-            _data[i].TryFormat(output[(i * 2)..], out _, "x2");
+            data[i].TryFormat(output[(i * 2)..], out _, "x2");
         }
 
         return output.ToString();

--- a/src/Rcl.NET/GraphId.cs
+++ b/src/Rcl.NET/GraphId.cs
@@ -1,0 +1,85 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Rcl;
+
+/// <summary>
+/// Represents a unique identifier for ROS communication entities.
+/// </summary>
+public unsafe struct GraphId : IEquatable<GraphId>
+{
+    private fixed byte _data[24];
+
+    private Span<byte> AsSpan()
+    {
+        fixed (void* p = _data)
+        {
+            return new(p, 24);
+        }
+    }
+
+    /// <summary>
+    /// Create a new <see cref="GraphId"/> with its value copied from a <see cref="ReadOnlySpan{Byte}"/>.
+    /// </summary>
+    /// <param name="data">The <see cref="ReadOnlySpan{Byte}"/> to be copied from. The size of the <paramref name="data"/> must be either 16 or 24 bytes.</param>
+    public unsafe GraphId(ReadOnlySpan<byte> data)
+    {
+        if (data.Length != 16 || data.Length != 24)
+        {
+            throw new ArgumentException($"Size of the GID data must be either 16 or 24 bytes.");
+        }
+
+        data.CopyTo(AsSpan());
+    }
+
+    /// <summary>
+    /// Create a new <see cref="GraphId"/> with its value copied from a <see cref="Guid"/>.
+    /// </summary>
+    /// <param name="guid">The <see cref="Guid"/> to be copied from.</param>
+    public GraphId(Guid guid)
+    {
+        guid.TryWriteBytes(AsSpan());
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+    {
+        if (obj is GraphId other)
+        {
+            return Equals(other);
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var data = MemoryMarshal.Cast<byte, long>(AsSpan());
+        return HashCode.Combine(data[0], data[1], data[2]);
+    }
+
+    /// <inheritdoc/>
+    public static bool operator ==(GraphId a, GraphId b)
+        => a.Equals(b);
+
+    /// <inheritdoc/>
+    public static bool operator !=(GraphId a, GraphId b)
+        => !(a == b);
+
+    /// <inheritdoc/>
+    public bool Equals(GraphId other) => AsSpan().SequenceEqual(other.AsSpan());
+
+    /// <summary>
+    /// Convert to <see cref="GraphId"/> to its string representation.
+    /// </summary>
+    /// <returns>A hexadecimal string representing the content of the <see cref="GraphId"/>.</returns>
+    public override string ToString()
+    {
+        Span<char> output = stackalloc char[24 * 2];
+        for (int i = 0; i < 24; i++)
+        {
+            _data[i].TryFormat(output[(i * 2)..], out _, "x2");
+        }
+
+        return output.ToString();
+    }
+}

--- a/src/Rcl.NET/GraphId.cs
+++ b/src/Rcl.NET/GraphId.cs
@@ -46,6 +46,11 @@ public unsafe struct GraphId : IEquatable<GraphId>
         guid.TryWriteBytes(AsSpan());
     }
 
+    /// <summary>
+    /// Represents an uninitialized <see cref="GraphId"/>.
+    /// </summary>
+    public static readonly GraphId Empty = default;
+
     /// <inheritdoc/>
     public override bool Equals(object? obj)
     {

--- a/src/Rcl.NET/IRclClient.cs
+++ b/src/Rcl.NET/IRclClient.cs
@@ -1,4 +1,6 @@
-﻿using Rosidl.Runtime;
+﻿using Rcl.Qos;
+using Rcl.Runtime;
+using Rosidl.Runtime;
 
 namespace Rcl;
 
@@ -25,6 +27,22 @@ public interface IRclClient<TRequest, TResponse> : IRclObject
     /// Gets the name of the service being invoked.
     /// </summary>
     string Name { get; }
+
+    /// <summary>
+    /// Configure service introspection for the client.
+    /// </summary>
+    /// <remarks>
+    /// Supported distro(s): >=iron
+    /// </remarks>
+    /// <param name="state">The desired state of service introspection.</param>
+    /// <param name="qos">
+    /// <see cref="QosProfile"/> to use when creating the introspection publisher.
+    /// <para>
+    /// Defaults to <see cref="QosProfile.SystemDefault"/>.
+    /// </para>
+    /// </param>
+    [SupportedSinceDistribution(RosEnvironment.Iron)]
+    void ConfigureIntrospection(ServiceIntrospectionState state, QosProfile? qos = null);
 
     /// <summary>
     /// Try wait for the server become available, or until timeout.

--- a/src/Rcl.NET/IRclClient.cs
+++ b/src/Rcl.NET/IRclClient.cs
@@ -29,6 +29,18 @@ public interface IRclClient<TRequest, TResponse> : IRclObject
     string Name { get; }
 
     /// <summary>
+    /// Gets the globally unique identifier (GID) of the service client.
+    /// </summary>
+    /// <remarks>
+    /// Supported by: >=iron
+    /// <para>
+    /// This property will return <see cref="GraphId.Empty"/> when accessed from an unsupported ROS distribution.
+    /// </para>
+    /// </remarks>
+    [SupportedSinceDistribution(RosEnvironment.Iron)]
+    GraphId Gid { get; }
+
+    /// <summary>
     /// Configure service introspection for the client.
     /// </summary>
     /// <remarks>

--- a/src/Rcl.NET/IRclPublisher.cs
+++ b/src/Rcl.NET/IRclPublisher.cs
@@ -30,6 +30,11 @@ public interface IRclPublisher : IRclObject
     string Name { get; }
 
     /// <summary>
+    /// Gets the globally unique identifier (GID) of the publisher.
+    /// </summary>
+    GraphId Gid { get; }
+
+    /// <summary>
     /// Gets the network flow endpoints of current publisher.
     /// </summary>
     /// <remarks>

--- a/src/Rcl.NET/IRclService.cs
+++ b/src/Rcl.NET/IRclService.cs
@@ -1,4 +1,6 @@
-﻿using Rosidl.Runtime;
+﻿using Rcl.Qos;
+using Rcl.Runtime;
+using Rosidl.Runtime;
 
 namespace Rcl;
 
@@ -16,6 +18,22 @@ public interface IRclService : IRclObject
     /// Gets the name of the service.
     /// </summary>
     string Name { get; }
+
+    /// <summary>
+    /// Configure service introspection for the server.
+    /// </summary>
+    /// <remarks>
+    /// Supported distro(s): >=iron
+    /// </remarks>
+    /// <param name="state">The desired state of service introspection.</param>
+    /// <param name="qos">
+    /// <see cref="QosProfile"/> to use when creating the introspection publisher.
+    /// <para>
+    /// Defaults to <see cref="QosProfile.SystemDefault"/>.
+    /// </para>
+    /// </param>
+    [SupportedSinceDistribution(RosEnvironment.Iron)]
+    void ConfigureIntrospection(ServiceIntrospectionState state, QosProfile? qos = null);
 }
 
 /// <summary>

--- a/src/Rcl.NET/Internal/Clients/RclClient.cs
+++ b/src/Rcl.NET/Internal/Clients/RclClient.cs
@@ -53,5 +53,4 @@ internal class RclClient<TService, TRequest, TResponse> : RclClientBase, IRclCli
 
     public Task<TResponse> InvokeAsync(TRequest request, CancellationToken cancellationToken = default)
         => InvokeAsync(request, Timeout.Infinite, cancellationToken);
-
 }

--- a/src/Rcl.NET/Internal/Clients/RclClientBase.cs
+++ b/src/Rcl.NET/Internal/Clients/RclClientBase.cs
@@ -28,7 +28,7 @@ internal abstract class RclClientBase : RclWaitObject<SafeClientHandle>
             RclIron.rmw_gid_t gid;
             var handle = rcl_client_get_rmw_handle(Handle.Object);
             RclException.ThrowIfNonSuccess(RclIron.rmw_get_gid_for_client(handle, &gid));
-            Gid = new(gid.data);
+            Gid = new(gid.GetGidSpan());
         }
 
         RegisterWaitHandle();

--- a/src/Rcl.NET/Internal/Clients/RclClientBase.cs
+++ b/src/Rcl.NET/Internal/Clients/RclClientBase.cs
@@ -23,6 +23,14 @@ internal abstract class RclClientBase : RclWaitObject<SafeClientHandle>
         _typesupport = typeSupport;
         Name = StringMarshal.CreatePooledString(rcl_client_get_service_name(Handle.Object))!;
 
+        if (RosEnvironment.IsSupported(RosEnvironment.Iron))
+        {
+            RclIron.rmw_gid_t gid;
+            var handle = rcl_client_get_rmw_handle(Handle.Object);
+            RclException.ThrowIfNonSuccess(RclIron.rmw_get_gid_for_client(handle, &gid));
+            Gid = new(gid.data);
+        }
+
         RegisterWaitHandle();
     }
 
@@ -70,6 +78,8 @@ internal abstract class RclClientBase : RclWaitObject<SafeClientHandle>
         => _node.Graph.WaitForServiceServerAsync(Name!, cancellationToken);
 
     public string Name { get; }
+
+    public GraphId Gid { get; }
 
     public unsafe bool IsValid
          => rcl_client_is_valid(Handle.Object);

--- a/src/Rcl.NET/Internal/Publishers/RclNativePublisher.cs
+++ b/src/Rcl.NET/Internal/Publishers/RclNativePublisher.cs
@@ -42,19 +42,10 @@ internal unsafe class RclNativePublisher : RclContextualObject<SafePublisherHand
             InitializePublisherEvents(options,
                 ref _livelinessEvent, ref _deadlineMissedEvent, ref _qosEvent);
 
+            rmw_gid_t gid;
             var rmwHandle = rcl_publisher_get_rmw_handle(Handle.Object);
-            if (RosEnvironment.IsSupported(RosEnvironment.Iron))
-            {
-                RclIron.rmw_gid_t gid;
-                RclException.ThrowIfNonSuccess(rmw_get_gid_for_publisher(rmwHandle, &gid));
-                Gid = new(gid.GetGidSpan());
-            }
-            else
-            {
-                rmw_gid_t gid;
-                RclException.ThrowIfNonSuccess(rmw_get_gid_for_publisher(rmwHandle, &gid));
-                Gid = new(gid.GetGidSpan());
-            }
+            RclException.ThrowIfNonSuccess(rmw_get_gid_for_publisher(rmwHandle, &gid));
+            Gid = new(gid.GetGidSpan()[..GraphId.Size]);
 
             completelyInitialized = true;
         }

--- a/src/Rcl.NET/Internal/Publishers/RclNativePublisher.cs
+++ b/src/Rcl.NET/Internal/Publishers/RclNativePublisher.cs
@@ -47,13 +47,13 @@ internal unsafe class RclNativePublisher : RclContextualObject<SafePublisherHand
             {
                 RclIron.rmw_gid_t gid;
                 RclException.ThrowIfNonSuccess(rmw_get_gid_for_publisher(rmwHandle, &gid));
-                Gid = new(gid.data);
+                Gid = new(gid.GetGidSpan());
             }
             else
             {
                 rmw_gid_t gid;
                 RclException.ThrowIfNonSuccess(rmw_get_gid_for_publisher(rmwHandle, &gid));
-                Gid = new(new ReadOnlySpan<byte>(gid.data, 24));
+                Gid = new(gid.GetGidSpan());
             }
 
             completelyInitialized = true;

--- a/src/Rcl.NET/Internal/Subscriptions/IntrospectionNativeSubscription.cs
+++ b/src/Rcl.NET/Internal/Subscriptions/IntrospectionNativeSubscription.cs
@@ -28,6 +28,10 @@ internal unsafe class IntrospectionNativeSubscription
         // if need to access header fields on foxy.
         // Defined as RclHumble.rmw_message_info_t only because it has bigger size
         // to be compatible with both foxy and humble.
+        //
+        // Size of the GID was changed from 24 bytes to 16 bytes since iron.
+        // We can still use RclHumble.rmw_message_info_t because it's bigger in size,
+        // unless we need to access rmw_message_info_t.from_intra_process.
         RclHumble.rmw_message_info_t header;
 
         var buffer = _introspection.CreateBuffer();

--- a/src/Rcl.NET/Internal/Subscriptions/NativeSubscription.cs
+++ b/src/Rcl.NET/Internal/Subscriptions/NativeSubscription.cs
@@ -21,6 +21,10 @@ internal unsafe class NativeSubscription<T> :
         // if need to access header fields on foxy.
         // Defined as RclHumble.rmw_message_info_t only because it has bigger size
         // to be compatible with both foxy and humble.
+        //
+        // Size of the GID was changed from 24 bytes to 16 bytes since iron.
+        // We can still use RclHumble.rmw_message_info_t because it's bigger in size,
+        // unless we need to access rmw_message_info_t.from_intra_process.
         RclHumble.rmw_message_info_t header;
 
         var rosMessage = RosMessageBuffer.Create<T>();

--- a/src/Rcl.NET/Internal/Subscriptions/RclSubscription.cs
+++ b/src/Rcl.NET/Internal/Subscriptions/RclSubscription.cs
@@ -100,6 +100,10 @@ internal unsafe class RclSubscription<T> :
         // if need to access header fields on foxy.
         // Defined as RclHumble.rmw_message_info_t only because it has bigger size
         // to be compatible with both foxy and humble.
+        //
+        // Size of the GID was changed from 24 bytes to 16 bytes since iron.
+        // We can still use RclHumble.rmw_message_info_t because it's bigger in size,
+        // unless we need to access rmw_message_info_t.from_intra_process.
         RclHumble.rmw_message_info_t header;
 
         try

--- a/src/Rcl.NET/Interop/RclCommon.cs
+++ b/src/Rcl.NET/Interop/RclCommon.cs
@@ -4844,6 +4844,6 @@ namespace Rcl.Interop
         public static extern nint rcl_client_get_rmw_handle(rcl_client_t* client);
 
         [DllImport("rmw_implementation", CallingConvention = CallingConvention.Cdecl)]
-        public static extern rcl_ret_t rmw_get_gid_for_publisher(nint rmwPubliherHandle, void* gid);
+        public static extern rcl_ret_t rmw_get_gid_for_publisher(nint rmw_publisher_handle, void* gid);
     }
 }

--- a/src/Rcl.NET/Interop/RclCommon.cs
+++ b/src/Rcl.NET/Interop/RclCommon.cs
@@ -4836,5 +4836,14 @@ namespace Rcl.Interop
         [SuppressGCTransition]
         [DllImport("rcl", CallingConvention = CallingConvention.Cdecl)]
         public static extern rcl_ret_t rcl_set_ros_time_override(rcl_clock_t* clock, rcl_time_point_value_t time_value);
+
+        [DllImport("rcl", CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint rcl_publisher_get_rmw_handle(rcl_publisher_t* publisher);
+
+        [DllImport("rcl", CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint rcl_client_get_rmw_handle(rcl_client_t* client);
+
+        [DllImport("rmw_implementation", CallingConvention = CallingConvention.Cdecl)]
+        public static extern rcl_ret_t rmw_get_gid_for_publisher(nint rmwPubliherHandle, void* gid);
     }
 }

--- a/src/Rcl.NET/Interop/RclCommon.cs
+++ b/src/Rcl.NET/Interop/RclCommon.cs
@@ -4556,7 +4556,7 @@ namespace Rcl.Interop
         /// Given `allocator` must be the same used to initialize the given `topic_endpoint_info_array`.
         /// </pre>
         [DllImport("rmw", CallingConvention = CallingConvention.Cdecl)]
-        public static extern rcl_ret_t rmw_topic_endpoint_info_array_fini(RclCommon.rmw_topic_endpoint_info_array_t* topic_endpoint_info_array, RclCommon.rcutils_allocator_t* allocator);
+        public static extern rcl_ret_t rmw_topic_endpoint_info_array_fini(void* topic_endpoint_info_array, RclCommon.rcutils_allocator_t* allocator);
 
         /// <summary>
         /// Return a list of service names and types associated with a node.
@@ -4739,7 +4739,7 @@ namespace Rcl.Interop
         /// &lt;i&gt;[1] implementation may need to protect the data structure with a lock&lt;/i&gt;
         /// </remarks>
         [DllImport("rcl", CallingConvention = CallingConvention.Cdecl)]
-        public static extern rcl_ret_t rcl_get_publishers_info_by_topic(RclCommon.rcl_node_t* node, RclCommon.rcutils_allocator_t* allocator, byte* topic_name, bool no_mangle, RclCommon.rmw_topic_endpoint_info_array_t* publishers_info);
+        public static extern rcl_ret_t rcl_get_publishers_info_by_topic(RclCommon.rcl_node_t* node, RclCommon.rcutils_allocator_t* allocator, byte* topic_name, bool no_mangle, void* publishers_info);
 
         /// <summary>
         /// Return a list of all subscriptions to a topic.
@@ -4778,7 +4778,7 @@ namespace Rcl.Interop
         /// &lt;i&gt;[1] implementation may need to protect the data structure with a lock&lt;/i&gt;
         /// </remarks>
         [DllImport("rcl", CallingConvention = CallingConvention.Cdecl)]
-        public static extern rcl_ret_t rcl_get_subscriptions_info_by_topic(RclCommon.rcl_node_t* node, RclCommon.rcutils_allocator_t* allocator, byte* topic_name, bool no_mangle, RclCommon.rmw_topic_endpoint_info_array_t* subscriptions_info);
+        public static extern rcl_ret_t rcl_get_subscriptions_info_by_topic(RclCommon.rcl_node_t* node, RclCommon.rcutils_allocator_t* allocator, byte* topic_name, bool no_mangle, void* subscriptions_info);
 
         /// <summary>
         /// Check if a service server is available for the given service client.

--- a/src/Rcl.NET/Interop/RclCommon.cs
+++ b/src/Rcl.NET/Interop/RclCommon.cs
@@ -676,6 +676,8 @@ namespace Rcl.Interop
             /// Bype data Gid value
             /// </summary>
             public fixed byte data[24];
+
+            public Span<byte> GetGidSpan() => MemoryMarshal.CreateSpan(ref data[0], 24);
         }
 
         /// <summary>
@@ -1564,6 +1566,8 @@ namespace Rcl.Interop
             /// QoS profile of the endpoint
             /// </summary>
             public RclCommon.rmw_qos_profile_t qos_profile;
+
+            public Span<byte> GetGidSpan() => MemoryMarshal.CreateSpan(ref endpoint_gid[0], 24);
         }
 
         /// <summary>

--- a/src/Rcl.NET/Interop/RclIron.cs
+++ b/src/Rcl.NET/Interop/RclIron.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Rcl.Interop;
+
+unsafe static class RclIron
+{
+    /// <summary>
+    /// ROS graph ID of the topic
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public partial struct rmw_gid_t
+    {
+        /// <summary>
+        /// Name of the rmw implementation
+        /// </summary>
+        public byte* implementation_identifier;
+
+        /// <summary>
+        /// Bype data Gid value
+        /// </summary>
+        public Guid data;
+    }
+
+    /// <summary>
+    /// Information describing an rmw message
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public partial struct rmw_message_info_t
+    {
+        public rcl_time_point_value_t source_timestamp;
+
+        public rcl_time_point_value_t received_timestamp;
+
+        public ulong publication_sequence_number;
+
+        public ulong reception_sequence_number;
+
+        public rmw_gid_t publisher_gid;
+
+        /// <summary>
+        /// Whether this message is from intra_process communication or not
+        /// </summary>
+        public bool from_intra_process;
+    }
+}

--- a/src/Rcl.NET/Interop/RclIron.cs
+++ b/src/Rcl.NET/Interop/RclIron.cs
@@ -42,4 +42,60 @@ unsafe static class RclIron
         /// </summary>
         public bool from_intra_process;
     }
+
+    /// <summary>
+    /// A data structure that encapsulates the node name, node namespace,
+    /// topic_type, gid, and qos_profile of publishers and subscriptions
+    /// for a topic.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public partial struct rmw_topic_endpoint_info_t
+    {
+        /// <summary>
+        /// Name of the node
+        /// </summary>
+        public byte* node_name;
+
+        /// <summary>
+        /// Namespace of the node
+        /// </summary>
+        public byte* node_namespace;
+
+        /// <summary>
+        /// The associated topic type
+        /// </summary>
+        public byte* topic_type;
+
+        /// <summary>
+        /// The endpoint type
+        /// </summary>
+        public rmw_endpoint_type_t endpoint_type;
+
+        /// <summary>
+        /// The GID of the endpoint
+        /// </summary>
+        public Guid endpoint_gid;
+
+        /// <summary>
+        /// QoS profile of the endpoint
+        /// </summary>
+        public rmw_qos_profile_t qos_profile;
+    }
+
+    /// <summary>
+    /// Array of topic endpoint information
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public partial struct rmw_topic_endpoint_info_array_t
+    {
+        /// <summary>
+        /// Size of the array.
+        /// </summary>
+        public size_t size;
+
+        /// <summary>
+        /// Contiguous storage for topic endpoint information elements.
+        /// </summary>
+        public rmw_topic_endpoint_info_t* info_array;
+    }
 }

--- a/src/Rcl.NET/Interop/RclIron.cs
+++ b/src/Rcl.NET/Interop/RclIron.cs
@@ -47,6 +47,15 @@ unsafe static class RclIron
         public bool from_intra_process;
     }
 
+    /// A ROS 2 interface type hash per REP-2011 RIHS standard.
+    public unsafe partial struct rosidl_type_hash_t
+    {
+        public byte version;
+        public fixed byte value[32];
+
+        public Span<byte> GetValueSpan() => MemoryMarshal.CreateSpan(ref value[0], 32);
+    }
+
     /// <summary>
     /// A data structure that encapsulates the node name, node namespace,
     /// topic_type, gid, and qos_profile of publishers and subscriptions
@@ -69,6 +78,11 @@ unsafe static class RclIron
         /// The associated topic type
         /// </summary>
         public byte* topic_type;
+
+        /// <summary>
+        /// Hashed value for topic type's description
+        /// </summary>
+        public rosidl_type_hash_t topic_type_hash;
 
         /// <summary>
         /// The endpoint type

--- a/src/Rcl.NET/Interop/RclIron.cs
+++ b/src/Rcl.NET/Interop/RclIron.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using Rosidl.Runtime.Interop;
+using System.Runtime.InteropServices;
+using static Rcl.Interop.RclHumble;
 
 namespace Rcl.Interop;
 
@@ -98,4 +100,33 @@ unsafe static class RclIron
         /// </summary>
         public rmw_topic_endpoint_info_t* info_array;
     }
+
+    public enum rcl_service_introspection_state_t
+    {
+        /// Introspection disabled
+        RCL_SERVICE_INTROSPECTION_OFF,
+        /// Introspect metadata only
+        RCL_SERVICE_INTROSPECTION_METADATA,
+        /// Introspection metadata and contents
+        RCL_SERVICE_INTROSPECTION_CONTENTS,
+    }
+
+    [DllImport("rcl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern rcl_ret_t rcl_service_configure_service_introspection(
+      rcl_service_t* service,
+      rcl_node_t* node,
+      rcl_clock_t* clock,
+      ServiceTypeSupport* type_support,
+      rcl_publisher_options_t publisher_options,
+      rcl_service_introspection_state_t introspection_state);
+
+    [DllImport("rcl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern rcl_ret_t rcl_client_configure_service_introspection(
+      rcl_client_t* client,
+      rcl_node_t* node,
+      rcl_clock_t* clock,
+      ServiceTypeSupport* type_support,
+      rcl_publisher_options_t publisher_options,
+      rcl_service_introspection_state_t introspection_state);
+
 }

--- a/src/Rcl.NET/Interop/RclIron.cs
+++ b/src/Rcl.NET/Interop/RclIron.cs
@@ -129,4 +129,7 @@ unsafe static class RclIron
       rcl_publisher_options_t publisher_options,
       rcl_service_introspection_state_t introspection_state);
 
+    [DllImport("rmw_implementation", CallingConvention = CallingConvention.Cdecl)]
+    public static extern rcl_ret_t rmw_get_gid_for_client(nint rmw_client_handle, void* gid);
+
 }

--- a/src/Rcl.NET/Interop/RclIron.cs
+++ b/src/Rcl.NET/Interop/RclIron.cs
@@ -20,7 +20,9 @@ unsafe static class RclIron
         /// <summary>
         /// Bype data Gid value
         /// </summary>
-        public Guid data;
+        public fixed byte data[16];
+
+        public Span<byte> GetGidSpan() => MemoryMarshal.CreateSpan(ref data[0], 16);
     }
 
     /// <summary>
@@ -76,12 +78,14 @@ unsafe static class RclIron
         /// <summary>
         /// The GID of the endpoint
         /// </summary>
-        public Guid endpoint_gid;
+        public fixed byte endpoint_gid[16];
 
         /// <summary>
         /// QoS profile of the endpoint
         /// </summary>
         public rmw_qos_profile_t qos_profile;
+
+        public Span<byte> GetGidSpan() => MemoryMarshal.CreateSpan(ref endpoint_gid[0], 16);
     }
 
     /// <summary>

--- a/src/Rcl.NET/Introspection/MessageIntrospection.cs
+++ b/src/Rcl.NET/Introspection/MessageIntrospection.cs
@@ -35,7 +35,7 @@ static class MessageIntrospection
         {
             return new FoxyMessageIntrospection(typesupport);
         }
-        else if (RosEnvironment.IsHumble)
+        else if (RosEnvironment.IsHumble || RosEnvironment.IsIron)
         {
             return new HumbleMessageIntrospection(typesupport);
         }
@@ -54,7 +54,7 @@ static class MessageIntrospection
         {
             return new FoxyMessageIntrospection(messageMembers);
         }
-        else if (RosEnvironment.IsHumble)
+        else if (RosEnvironment.IsHumble || RosEnvironment.IsIron)
         {
             return new HumbleMessageIntrospection(messageMembers);
         }

--- a/src/Rcl.NET/Introspection/ServiceIntrospection.cs
+++ b/src/Rcl.NET/Introspection/ServiceIntrospection.cs
@@ -14,6 +14,7 @@ internal unsafe class ServiceIntrospection
 
     public ServiceIntrospection(ServiceTypeSupport* ts)
     {
+        TypeSupportHandle = ts;
         fixed (byte* id = TypeSupportIdentifier.Introspection)
         {
             ts = ts->Handler(ts, (sbyte*)id);
@@ -23,6 +24,8 @@ internal unsafe class ServiceIntrospection
             _typesupport = serviceMembers;
         }
     }
+
+    public ServiceTypeSupport* TypeSupportHandle { get; }
 
     public string Name => StringMarshal.CreatePooledString(_typesupport->ServiceName)!;
 

--- a/src/Rcl.NET/Options.cs
+++ b/src/Rcl.NET/Options.cs
@@ -372,7 +372,7 @@ public record SubscriptionOptions
     public SubscriptionOptions(
         QosProfile? qos = null,
         Encoding? textEncoding = null,
-        int queueSize = 1,
+        int queueSize = 64,
         BoundedChannelFullMode fullMode = BoundedChannelFullMode.DropOldest,
         Action<LivelinessChangedEvent>? livelinessChangedHandler = null,
         Action<RequestedDeadlineMissedEvent>? requestedDeadlineMissedHandler = null,

--- a/src/Rcl.NET/Parameters/Impl/ParameterService.cs
+++ b/src/Rcl.NET/Parameters/Impl/ParameterService.cs
@@ -98,7 +98,7 @@ partial class ParameterService : IParameterService, IDisposable
         {
             return &((RclFoxy.rcl_node_options_t*)handle)->arguments;
         }
-        else if (RosEnvironment.IsHumble)
+        else if (RosEnvironment.IsHumble || RosEnvironment.IsIron)
         {
             return &((RclHumble.rcl_node_options_t*)handle)->arguments;
         }

--- a/src/Rcl.NET/RclContext.cs
+++ b/src/Rcl.NET/RclContext.cs
@@ -69,7 +69,7 @@ public sealed class RclContext : IRclContext
     /// </param>
     public unsafe RclContext(string[] args, IRclLoggerFactory? loggerFactory = null, bool useSynchronizationContext = false)
     {
-        if (!RosEnvironment.IsFoxy && !RosEnvironment.IsHumble)
+        if (!RosEnvironment.IsSupported(RosEnvironment.Distribution))
         {
             string message;
             if (RosEnvironment.Distribution == string.Empty)

--- a/src/Rcl.NET/RosEnvironment.cs
+++ b/src/Rcl.NET/RosEnvironment.cs
@@ -29,7 +29,7 @@ public unsafe static class RosEnvironment
     /// <summary>
     /// ROS 2 Iron Irwini.
     /// </summary>
-    public const string Iron = "rolling"; // TODO: Change 'rolling' to 'iron' when release.
+    public const string Iron = "iron";
 
     /// <summary>
     /// Gets whether the application is running in foxy.

--- a/src/Rcl.NET/RosEnvironment.cs
+++ b/src/Rcl.NET/RosEnvironment.cs
@@ -14,7 +14,7 @@ internal enum VersionRequirement
 /// </summary>
 public unsafe static class RosEnvironment
 {
-    private static readonly string[] SupportedDistributions = new[] { Foxy, Humble };
+    private static readonly string[] SupportedDistributions = new[] { Foxy, Humble, Iron };
 
     /// <summary>
     /// ROS 2 Foxy Fitzroy.
@@ -27,6 +27,11 @@ public unsafe static class RosEnvironment
     public const string Humble = "humble";
 
     /// <summary>
+    /// ROS 2 Iron Irwini.
+    /// </summary>
+    public const string Iron = "rolling"; // TODO: Change 'rolling' to 'iron' when release.
+
+    /// <summary>
     /// Gets whether the application is running in foxy.
     /// </summary>
     public static bool IsFoxy => Distribution == Foxy;
@@ -35,6 +40,11 @@ public unsafe static class RosEnvironment
     /// Gets whether the application is running in humble.
     /// </summary>
     public static bool IsHumble => Distribution == Humble;
+
+    /// <summary>
+    /// Gets whether the application is running in iron.
+    /// </summary>
+    public static bool IsIron => Distribution == Iron;
 
     /// <summary>
     /// Get the name of the rmw implementation being used.

--- a/src/Rcl.NET/SafeHandles/SafeNodeHandle.cs
+++ b/src/Rcl.NET/SafeHandles/SafeNodeHandle.cs
@@ -28,7 +28,10 @@ unsafe class SafeNodeHandle : RclObjectHandle<rcl_node_t>
                 switch (RosEnvironment.Distribution)
                 {
                     case RosEnvironment.Foxy: InitFoxy(namePtr, nsPtr, context, options); break;
-                    case RosEnvironment.Humble: InitHumble(namePtr, nsPtr, context, options); break;
+                    case RosEnvironment.Humble:
+                    case RosEnvironment.Iron:
+                        InitHumbleOrLater(namePtr, nsPtr, context, options);
+                        break;
                     default: throw new NotImplementedException();
                 }
             }
@@ -58,7 +61,7 @@ unsafe class SafeNodeHandle : RclObjectHandle<rcl_node_t>
                 rcl_node_init(Object, namePtr, nsPtr, context.Object, &opts));
     }
 
-    private void InitHumble(byte* namePtr, byte* nsPtr, SafeContextHandle context, NodeOptions options)
+    private void InitHumbleOrLater(byte* namePtr, byte* nsPtr, SafeContextHandle context, NodeOptions options)
     {
         var opts = RclHumble.rcl_node_get_default_options();
 

--- a/src/Rcl.NET/ServiceIntrospection.cs
+++ b/src/Rcl.NET/ServiceIntrospection.cs
@@ -1,0 +1,22 @@
+﻿namespace Rcl;
+
+/// <summary>
+/// The introspection state for a service client or service server.
+/// </summary>
+public enum ServiceIntrospectionState
+{
+    /// <summary>
+    /// Introspection is disabled for the service.
+    /// </summary>
+    Disabled,
+
+    /// <summary>
+    /// The metadata is published for the service.
+    /// </summary>
+    MetadataOnly,
+
+    /// <summary>
+    /// The metadata and service request and response contents are published for the service.
+    /// </summary>
+    Full
+}

--- a/src/Rosidl.Generator.CSharp/BuildContext.cs
+++ b/src/Rosidl.Generator.CSharp/BuildContext.cs
@@ -47,6 +47,7 @@ public enum MessageType
     Plain,
     ServiceRequest,
     ServiceResponse,
+    ServiceEvent,
     ActionGoal,
     ActionFeedback,
     ActionResult,

--- a/src/Rosidl.Generator.CSharp/BuildContext.cs
+++ b/src/Rosidl.Generator.CSharp/BuildContext.cs
@@ -1,4 +1,6 @@
 ﻿using CppAst.CodeGen.CSharp;
+using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace Rosidl.Generator.CSharp;
@@ -18,7 +20,8 @@ static class Attributes
         = new CSharpFreeAttribute("global::System.Diagnostics.DebuggerNonUserCodeAttribute");
 
     public static readonly CSharpAttribute GeneratedCode
-        = new CSharpFreeAttribute("global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Rosidl.Runtime.Generator.CSharp\", \"1.0.0\")");
+        = new CSharpFreeAttribute($"global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"ros2cs\", " +
+            $"\"{FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion}\")");
 }
 
 public record VariableFieldInfo(

--- a/src/Rosidl.Generator.CSharp/CSharpCodeGenerator.cs
+++ b/src/Rosidl.Generator.CSharp/CSharpCodeGenerator.cs
@@ -13,17 +13,6 @@ record Package(string Name, Message[] Messages);
 
 class ParseSpec
 {
-    private static bool IsServiceIntrospectionSupported()
-    {
-        var distro = Environment.GetEnvironmentVariable("ROS_DISTRO");
-        if (distro == "rolling" || distro == "iron")
-        {
-            return true;
-        }
-
-        return false;
-    }
-
     public Dictionary<string, string> NamespaceMapping { get; } = new();
 
     public Dictionary<string, string> PackageMapping { get; } = new();
@@ -42,7 +31,7 @@ class ParseSpec
 
     public bool IsInternal { get; } = false;
 
-    public bool EnableServiceIntrospection { get; } = IsServiceIntrospectionSupported();
+    public bool EnableServiceIntrospection { get; } = false;
 
     public bool EnableActionDetails { get; } = false;
 

--- a/src/Rosidl.Generator.CSharp/CSharpCodeGenerator.cs
+++ b/src/Rosidl.Generator.CSharp/CSharpCodeGenerator.cs
@@ -13,6 +13,17 @@ record Package(string Name, Message[] Messages);
 
 class ParseSpec
 {
+    private static bool IsServiceIntrospectionSupported()
+    {
+        var distro = Environment.GetEnvironmentVariable("ROS_DISTRO");
+        if (distro == "rolling" || distro == "iron")
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     public Dictionary<string, string> NamespaceMapping { get; } = new();
 
     public Dictionary<string, string> PackageMapping { get; } = new();
@@ -30,6 +41,10 @@ class ParseSpec
     public List<string> Excludes { get; } = new();
 
     public bool IsInternal { get; } = false;
+
+    public bool EnableServiceIntrospection { get; } = IsServiceIntrospectionSupported();
+
+    public bool EnableActionDetails { get; } = false;
 
     public ParseSpec(string specFile)
     {
@@ -66,6 +81,30 @@ class ParseSpec
                 case "map-namespace":
                     var mapping = parts[1].Split(':');
                     NamespaceMapping.Add(mapping[0], mapping[1]);
+                    break;
+                case "service-introspection":
+                    if (parts.Length != 2)
+                    {
+                        throw new Exception($"'service-introspection' requires exactly one argument.");
+                    }
+                    EnableServiceIntrospection = parts[1] switch
+                    {
+                        "on" => true,
+                        "off" => false,
+                        _ => throw new Exception($"'{parts[1]}' is not a valid value for 'service-introspection' directive."),
+                    };
+                    break;
+                case "action-details":
+                    if (parts.Length != 2)
+                    {
+                        throw new Exception($"'action-details' requires exactly one argument.");
+                    }
+                    EnableActionDetails = parts[1] switch
+                    {
+                        "on" => true,
+                        "off" => false,
+                        _ => throw new Exception($"'{parts[1]}' is not a valid value for 'action-details' directive."),
+                    };
                     break;
                 case "map-package":
                     var p = parts[1].Split(':');
@@ -131,7 +170,7 @@ public class CSharpCodeGenerator
         var unresolved = new List<string>();
         while (true)
         {
-            var deps = ResolveDependencies(includedPackages);
+            var deps = ResolveDependencies(includedPackages, spec);
             if (deps.Count == 0 || deps.All(unresolved.Contains)) break;
 
             foreach (var dep in deps)
@@ -171,9 +210,9 @@ public class CSharpCodeGenerator
                     dir = Path.Combine(dir, "Actions");
                     if (!Directory.Exists(dir))
                         Directory.CreateDirectory(dir);
-                    var ctx = new ActionBuildContext(action, opts);
+                    var ctx = new ActionBuildContext(action, opts, parser);
                     code = new ActionClassBuilder(ctx)
-                        .Build($"{msg.Name}.cs", spec.IsInternal);
+                        .Build($"{msg.Name}.cs", spec.IsInternal, spec.EnableServiceIntrospection, spec.EnableActionDetails);
                 }
                 else if (metadata is ServiceMetadata service)
                 {
@@ -182,7 +221,7 @@ public class CSharpCodeGenerator
                         Directory.CreateDirectory(dir);
                     var ctx = new ServiceBuildContext(service, opts);
                     code = new ServiceClassBuilder(ctx)
-                        .Build($"{msg.Name}.cs", spec.IsInternal);
+                        .Build($"{msg.Name}.cs", spec.IsInternal, spec.EnableServiceIntrospection);
                 }
                 else
                 {
@@ -259,7 +298,7 @@ public class CSharpCodeGenerator
             try
             {
                 var root = XDocument.Load(packageXml);
-                if (root.Element("package")!.Element("member_of_group")!.Value != "rosidl_interface_packages")
+                if (root.Element("package")!.Element("member_of_group")?.Value != "rosidl_interface_packages")
                 {
                     return false;
                 }
@@ -332,7 +371,7 @@ public class CSharpCodeGenerator
         }
     }
 
-    private static List<string> ResolveDependencies(Dictionary<string, Package> packages)
+    private static List<string> ResolveDependencies(Dictionary<string, Package> packages, ParseSpec spec)
     {
         var missing = new List<string>();
 
@@ -350,17 +389,41 @@ public class CSharpCodeGenerator
                 {
                     ResolveFields(packages, s.RequestFields, missing);
                     ResolveFields(packages, s.ResponseFields, missing);
+
+                    if (spec.EnableServiceIntrospection)
+                    {
+                        Requires("service_msgs");
+                    }
                 }
                 else if (metadata is ActionMetadata a)
                 {
                     ResolveFields(packages, a.GoalFields, missing);
                     ResolveFields(packages, a.ResultFields, missing);
                     ResolveFields(packages, a.FeedbackFields, missing);
+
+                    if (spec.EnableServiceIntrospection)
+                    {
+                        Requires("service_msgs");
+                    }
+
+                    if (spec.EnableActionDetails)
+                    {
+                        Requires("builtin_interfaces");
+                        Requires("unique_identifier_msgs");
+                    }
                 }
             }
         }
 
         return missing;
+
+        void Requires(string package)
+        {
+            if (!packages.ContainsKey(package) && !missing.Contains(package))
+            {
+                missing.Add(package);
+            }
+        }
     }
 
     private static void ResolveFields(Dictionary<string, Package> packages, IEnumerable<FieldMetadata> fields, List<string> missingDependencies)

--- a/src/Rosidl.Generator.CSharp/Helpers/Extensions.cs
+++ b/src/Rosidl.Generator.CSharp/Helpers/Extensions.cs
@@ -24,13 +24,13 @@ internal static class Extensions
         cls.BaseTypes.Add(new CSharpFreeType(
             context.Type switch
             {
-                MessageType.Plain => "global::Rosidl.Runtime.IMessage",
+                MessageType.Plain or MessageType.ActionFeedbackMessage => "global::Rosidl.Runtime.IMessage",
                 MessageType.ServiceRequest => "global::Rosidl.Runtime.IServiceRequest",
                 MessageType.ServiceResponse => "global::Rosidl.Runtime.IServiceResponse",
+                MessageType.ServiceEvent => "global::Rosidl.Runtime.IServiceEvent",
                 MessageType.ActionGoal => "global::Rosidl.Runtime.IActionGoal",
                 MessageType.ActionFeedback => "global::Rosidl.Runtime.IActionFeedback",
                 MessageType.ActionResult => "global::Rosidl.Runtime.IActionResult",
-                MessageType.ActionFeedbackMessage => "global::Rosidl.Runtime.IActionFeedbackMessage",
                 _ => throw new NotSupportedException()
             }
         ));

--- a/src/Rosidl.Generator.CSharp/MsgParser.cs
+++ b/src/Rosidl.Generator.CSharp/MsgParser.cs
@@ -297,7 +297,7 @@ public class MsgParser
         return seperators switch
         {
             0 => ParseMessage(package, subFolder ?? "msg", name, statements),
-            1 => ParseService(package, subFolder ?? "svc", name, statements),
+            1 => ParseService(package, subFolder ?? "srv", name, statements),
             2 => ParseAction(package, subFolder ?? "action", name, statements),
             _ => throw new FormatException($"Unexpected count of seperators. Expecting 0, 1 or 2, received {seperators}.")
         };
@@ -310,7 +310,7 @@ public class MsgParser
         return seperators switch
         {
             0 => ParseMessage(package, subFolder ?? "msg", name, statements),
-            1 => ParseService(package, subFolder ?? "svc", name, statements),
+            1 => ParseService(package, subFolder ?? "srv", name, statements),
             2 => ParseAction(package, subFolder ?? "action", name, statements),
             _ => throw new FormatException($"Unexpected count of seperators. Expecting 0, 1 or 2, received {seperators}.")
         };

--- a/src/Rosidl.Generator.CSharp/TypeMetadata.cs
+++ b/src/Rosidl.Generator.CSharp/TypeMetadata.cs
@@ -55,6 +55,8 @@ public record MessageMetadata(
         return string.IsNullOrEmpty(SubFolder) ?
             $"{Package}/{Name}" : $"{Package}/{SubFolder}/{Name}";
     }
+
+    public ComplexTypeMetadata Ref() => new(Package, SubFolder, Name);
 }
 
 public record ServiceMetadata(
@@ -63,7 +65,8 @@ public record ServiceMetadata(
     string Name,
     string[] Comments,
     IReadOnlyCollection<FieldMetadata> RequestFields,
-    IReadOnlyCollection<FieldMetadata> ResponseFields
+    IReadOnlyCollection<FieldMetadata> ResponseFields,
+    IReadOnlyCollection<FieldMetadata> EventFields
 ) : ComplexTypeMetadata(Package, SubFolder, Name)
 {
     public override string ToString()

--- a/src/Rosidl.Runtime/TypeSupportInterfaces.cs
+++ b/src/Rosidl.Runtime/TypeSupportInterfaces.cs
@@ -131,6 +131,11 @@ public interface IServiceRequest : IMessage { }
 public interface IServiceResponse : IMessage { }
 
 /// <summary>
+/// Represents a service introspection event.
+/// </summary>
+public interface IServiceEvent: IMessage { }
+
+/// <summary>
 /// Represents an ROS action goal message.
 /// </summary>
 public interface IActionGoal : IMessage { }

--- a/src/ros2cs/ros2cs.spec
+++ b/src/ros2cs/ros2cs.spec
@@ -2,6 +2,28 @@
 # A path relative to this file or an absolute path can be used.
 output ./
 
+# Generate code for service introspection.
+#
+# This feature requires 'service_msgs' package.
+#
+# If ROS_DISTRO indicates a distribution which supports service introspection
+# and this directive is not specfied, then 'on' is used as the default value.
+# Otherwise, defaults to 'off'.
+# service-introspection [on|off]
+
+# Generate implementation details for actions, including FeedbackMessage,
+# SendGoal request/response and GetResult request/response.
+#
+# This feature requires 'unique_identifier_msgs' and 'builtin_interfaces' package.
+#
+# Detail messages are not neccesary for using action servers and clients as rclnet
+# utilizes introspection to construct and extract Feedback / Goal and Result messages.
+# Enabling 'action-details' will allow you to perform service introspection on Result
+# and Goal services, or manually subscribe Feedback messages, at the cost of increased
+# code size.
+# The default value is 'off'.
+# action-details [on|off]
+
 # Generate classes with internal visibility rather than public.
 # internal
 

--- a/src/ros2cs/ros2cs.spec
+++ b/src/ros2cs/ros2cs.spec
@@ -3,12 +3,8 @@
 output ./
 
 # Generate code for service introspection.
-#
 # This feature requires 'service_msgs' package.
-#
-# If ROS_DISTRO indicates a distribution which supports service introspection
-# and this directive is not specfied, then 'on' is used as the default value.
-# Otherwise, defaults to 'off'.
+# The default value is 'off'.
 # service-introspection [on|off]
 
 # Generate implementation details for actions, including FeedbackMessage,

--- a/src/testEnvironments.json
+++ b/src/testEnvironments.json
@@ -14,12 +14,17 @@
     {
       "name": "Container - Foxy",
       "type": "docker",
-      "dockerFile": "Rcl.NET.Tests/foxy.Dockerfile"
+      "dockerImage": "Rcl.NET.Tests/foxy.Dockerfile"
     },
     {
       "name": "Container - Humble",
       "type": "docker",
       "dockerFile": "Rcl.NET.Tests/humble.Dockerfile"
+    },
+    {
+      "name": "Container - Iron",
+      "type": "docker",
+      "dockerFile": "Rcl.NET.Tests/iron.Dockerfile"
     }
   ]
 }

--- a/src/testEnvironments.json
+++ b/src/testEnvironments.json
@@ -14,7 +14,7 @@
     {
       "name": "Container - Foxy",
       "type": "docker",
-      "dockerImage": "Rcl.NET.Tests/foxy.Dockerfile"
+      "dockerFile": "Rcl.NET.Tests/foxy.Dockerfile"
     },
     {
       "name": "Container - Humble",

--- a/templates/templates/ros2-msg/Company.MessageLibrary1.csproj
+++ b/templates/templates/ros2-msg/Company.MessageLibrary1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rosidl.Runtime" Version="1.1.1" />
+    <PackageReference Include="Rosidl.Runtime" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/templates/templates/ros2-node/Company.Node1.csproj
+++ b/templates/templates/ros2-node/Company.Node1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rcl.NET" Version="1.1.1" />
+    <PackageReference Include="Rcl.NET" Version="1.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR mainly addresses binary compatibility issues with [ROS 2 Iron Irwini](https://docs.ros.org/en/iron/Releases/Release-Iron-Irwini.html), and adds several new features:

- [Service Introspection](https://github.com/ros-infrastructure/rep/blob/jacob/service_introspection/rep-2012.rst) (FastRTPS only)
- ros2cs: Service introspection event message generation
- Expose GID for service clients, publishers and subscribers